### PR TITLE
Add CI configuration with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: Build
+on: [push, pull_request]
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    env:
+      CC: gcc-10
+      CXX: g++-10
+    steps:
+      - uses: actions/checkout@v2
+      - run: cmake . -DLUNASVG_BUILD_EXAMPLES=ON
+      - run: make -j 2
+
+  macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: cmake . -DLUNASVG_BUILD_EXAMPLES=ON
+      - run: cmake --build .
+
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: cmake . -DLUNASVG_BUILD_EXAMPLES=ON
+      - run: cmake --build .
+      - uses: actions/upload-artifact@v2
+        with:
+          name: svg2png-windows
+          path: example\*\svg2png.exe


### PR DESCRIPTION
Add a CI configuration that builds the lunasvg libary and the example executable on Ubuntu (with GCC), on macOS (with Xcode) and on Windows with Visual Studio. It also uploads the svg2png.exe as an artifact for Windows.