### PR TITLE
Remove STATIC option from add_library and export DLL symbols on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,10 @@ project(lunasvg VERSION 2.0.1 LANGUAGES CXX C)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_C_STANDARD 11)
 
+option(BUILD_SHARED_LIBS "Builds as shared library" OFF)
 option(LUNASVG_BUILD_EXAMPLES "Builds examples" OFF)
 
-add_library(lunasvg STATIC)
+add_library(lunasvg)
 
 add_subdirectory(include)
 add_subdirectory(source)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,11 @@ add_subdirectory(source)
 add_subdirectory(3rdparty/software)
 add_subdirectory(3rdparty/plutovg)
 
+if(BUILD_SHARED_LIBS)
+    target_compile_definitions(lunasvg PUBLIC LUNASVG_SHARED)
+    target_compile_definitions(lunasvg PRIVATE LUNASVG_EXPORT)
+endif()
+
 if(LUNASVG_BUILD_EXAMPLES)
     add_subdirectory(example)
 endif()

--- a/include/document.h
+++ b/include/document.h
@@ -4,9 +4,19 @@
 #include <memory>
 #include <string>
 
+#if defined(_MSC_VER) && defined(LUNASVG_SHARED)
+# ifdef LUNASVG_EXPORT
+#  define DLLEXPORT __declspec(dllexport)
+# else
+#  define DLLEXPORT __declspec(dllimport)
+# endif
+#else
+# define DLLEXPORT
+#endif
+
 namespace lunasvg {
 
-class Bitmap
+class DLLEXPORT Bitmap
 {
 public:
     /**
@@ -30,7 +40,7 @@ private:
     std::shared_ptr<Impl> m_impl;
 };
 
-class Box
+class DLLEXPORT Box
 {
 public:
     Box() = default;
@@ -43,7 +53,7 @@ public:
     double h{0};
 };
 
-class Matrix
+class DLLEXPORT Matrix
 {
 public:
     Matrix() = default;
@@ -60,7 +70,7 @@ public:
 
 class LayoutRoot;
 
-class Document
+class DLLEXPORT Document
 {
 public:
     /**
@@ -198,5 +208,7 @@ private:
 };
 
 } //namespace lunasvg
+
+#undef DLLEXPORT
 
 #endif // DOCUMENT_H

--- a/include/document.h
+++ b/include/document.h
@@ -209,6 +209,4 @@ private:
 
 } //namespace lunasvg
 
-#undef LUNASVG_DLLEXPORT
-
 #endif // DOCUMENT_H

--- a/include/document.h
+++ b/include/document.h
@@ -6,17 +6,17 @@
 
 #if defined(_MSC_VER) && defined(LUNASVG_SHARED)
 # ifdef LUNASVG_EXPORT
-#  define DLLEXPORT __declspec(dllexport)
+#  define LUNASVG_DLLEXPORT __declspec(dllexport)
 # else
-#  define DLLEXPORT __declspec(dllimport)
+#  define LUNASVG_DLLEXPORT __declspec(dllimport)
 # endif
 #else
-# define DLLEXPORT
+# define LUNASVG_DLLEXPORT
 #endif
 
 namespace lunasvg {
 
-class DLLEXPORT Bitmap
+class LUNASVG_DLLEXPORT Bitmap
 {
 public:
     /**
@@ -40,7 +40,7 @@ private:
     std::shared_ptr<Impl> m_impl;
 };
 
-class DLLEXPORT Box
+class LUNASVG_DLLEXPORT Box
 {
 public:
     Box() = default;
@@ -53,7 +53,7 @@ public:
     double h{0};
 };
 
-class DLLEXPORT Matrix
+class LUNASVG_DLLEXPORT Matrix
 {
 public:
     Matrix() = default;
@@ -70,7 +70,7 @@ public:
 
 class LayoutRoot;
 
-class DLLEXPORT Document
+class LUNASVG_DLLEXPORT Document
 {
 public:
     /**
@@ -209,6 +209,6 @@ private:
 
 } //namespace lunasvg
 
-#undef DLLEXPORT
+#undef LUNASVG_DLLEXPORT
 
 #endif // DOCUMENT_H


### PR DESCRIPTION
closes #38 

Seems to be working. Only thing is I get warning [C4251](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4251?view=msvc-160), which pretty much just means "be careful when mixing DLLs".