### PR TITLE
Fix stride in bitmap clear and convert

### DIFF
--- a/source/lunasvg.cpp
+++ b/source/lunasvg.cpp
@@ -87,9 +87,12 @@ void Bitmap::clear(std::uint32_t color)
 
     auto width = this->width();
     auto height = this->height();
-    auto data = this->data();
+    auto stride = this->stride();
+    auto rowData = this->data();
+
     for(int y = 0;y < height;y++)
     {
+        auto data = rowData;
         for(int x = 0;x < width;x++)
         {
             data[0] = pb;
@@ -98,6 +101,7 @@ void Bitmap::clear(std::uint32_t color)
             data[3] = a;
             data += 4;
         }
+        rowData += stride;
     }
 }
 
@@ -105,9 +109,12 @@ void Bitmap::convert(int ri, int gi, int bi, int ai, bool unpremultiply)
 {
     auto width = this->width();
     auto height = this->height();
-    auto data = this->data();
+    auto stride = this->stride();
+    auto rowData = this->data();
+
     for(int y = 0;y < height;y++)
     {
+        auto data = rowData;
         for(int x = 0;x < width;x++)
         {
             auto b = data[0];
@@ -128,6 +135,7 @@ void Bitmap::convert(int ri, int gi, int bi, int ai, bool unpremultiply)
             data[ai] = a;
             data += 4;
         }
+        rowData += stride;
     }
 }
 


### PR DESCRIPTION
Calling `clear` from https://github.com/sammycage/lunasvg/commit/0d3e6a2897a76c907becbe48c1726685531ab455 for https://github.com/sammycage/lunasvg/issues/73 causes other adjacent bitmaps to be wiped out too because the outer loop ignores byte stride (I'm rendering multiple into a larger atlas texture with stride) while leaving bottom rows uncleared.

e.g. my calling code
```
for (uint32_t iconIndex; iconIndex < totalIcons; ++iconIndex)
{
    ...
    // Draw the icon into a subrect of the larger atlas texture,
    // adjusting the pointer offset while keeping the correct stride.
    uint32_t pixelOffset = y * atlasBitmap.stride() + x * sizeof(uint32_t);
    renderBitmap.reset(g_bitmap.data() + pixelOffset, iconSize, iconSize, atlasBitmap.stride());
    renderBitmap.clear(BgraToAbgr(backgroundColor));
    ...
    svgDocument->render(renderBitmap, matrix);
    ...
}
```
