### PR TITLE
Appease build warnings in Bitmap::convert for VS 2019

### DIFF
--- a/source/lunasvg.cpp
+++ b/source/lunasvg.cpp
@@ -90,10 +90,10 @@ void Bitmap::clear(std::uint32_t color)
     auto stride = this->stride();
     auto rowData = this->data();
 
-    for(unsigned int y = 0;y < height;y++)
+    for(std::uint32_t y = 0;y < height;y++)
     {
         auto data = rowData;
-        for(unsigned int x = 0;x < width;x++)
+        for(std::uint32_t x = 0;x < width;x++)
         {
             data[0] = pb;
             data[1] = pg;
@@ -112,10 +112,10 @@ void Bitmap::convert(int ri, int gi, int bi, int ai, bool unpremultiply)
     auto stride = this->stride();
     auto rowData = this->data();
 
-    for(unsigned int y = 0;y < height;y++)
+    for(std::uint32_t y = 0;y < height;y++)
     {
         auto data = rowData;
-        for(unsigned int x = 0;x < width;x++)
+        for(std::uint32_t x = 0;x < width;x++)
         {
             auto b = data[0];
             auto g = data[1];

--- a/source/lunasvg.cpp
+++ b/source/lunasvg.cpp
@@ -90,10 +90,10 @@ void Bitmap::clear(std::uint32_t color)
     auto stride = this->stride();
     auto rowData = this->data();
 
-    for(int y = 0;y < height;y++)
+    for(unsigned int y = 0;y < height;y++)
     {
         auto data = rowData;
-        for(int x = 0;x < width;x++)
+        for(unsigned int x = 0;x < width;x++)
         {
             data[0] = pb;
             data[1] = pg;
@@ -112,10 +112,10 @@ void Bitmap::convert(int ri, int gi, int bi, int ai, bool unpremultiply)
     auto stride = this->stride();
     auto rowData = this->data();
 
-    for(int y = 0;y < height;y++)
+    for(unsigned int y = 0;y < height;y++)
     {
         auto data = rowData;
-        for(int x = 0;x < width;x++)
+        for(unsigned int x = 0;x < width;x++)
         {
             auto b = data[0];
             auto g = data[1];


### PR DESCRIPTION
The code otherwise builds clean except for these few:

```
D:\src\LunaSvgTest\external\lunasvg\source\lunasvg.cpp(93): warning C4018: '<': signed/unsigned mismatch
D:\src\LunaSvgTest\external\lunasvg\source\lunasvg.cpp(96): warning C4018: '<': signed/unsigned mismatch
...
```