### PR TITLE
Fix use href

### DIFF
--- a/source/parser.cpp
+++ b/source/parser.cpp
@@ -1025,6 +1025,7 @@ static const std::map<std::string, PropertyId> propertymap = {
     {"gradientTransform", PropertyId::GradientTransform},
     {"gradientUnits", PropertyId::GradientUnits},
     {"height", PropertyId::Height},
+    {"href", PropertyId::Href},
     {"id", PropertyId::Id},
     {"markerHeight", PropertyId::MarkerHeight},
     {"markerUnits", PropertyId::MarkerUnits},


### PR DESCRIPTION
The following reduced repro doesn't display in LunaSvg (but does in Inkscape and Chrome):

```
<?xml version='1.0' encoding='UTF-8'?>
<!-- Created with Inkscape (http://www.inkscape.org/) and export_objects.py -->
<svg xmlns="http://www.w3.org/2000/svg" version="1.1" id="svg1" width="64" height="64" viewBox="0 0 64 64">
    <defs>
        <circle
             style="fill:#FF3300"
             id="path20"
             cx="0"
             cy="0"
             r="10"
             visibility="visible"
        />
    </defs>
    <use href="#path20" x="0" y="0" />
    <use href="#path20" x="30" y="20" />
</svg>
```

I debugged it to the `propertymap` table, which is missing `href`, containing only `xlink:href` which is [deprecated](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use) "This feature is no longer recommended ... kept for compatibility purposes". Everything else `use`-related works after adding that line.