### PR TITLE
Set stop::offset default/initial value = 0

### DIFF
--- a/source/stopelement.cpp
+++ b/source/stopelement.cpp
@@ -11,7 +11,7 @@ StopElement::StopElement()
 double StopElement::offset() const
 {
     auto& value = get(PropertyId::Offset);
-    return Parser::parseNumberPercentage(value, 1.0);
+    return Parser::parseNumberPercentage(value, 0.0);
 }
 
 Color StopElement::stopColorWithOpacity() const


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Web/SVG/Element/stop and https://svgwg.org/svg2-draft/pservers.html#GradientStopAttributes, set initial/default value = 0 when `offset` is absent for gradients, as some tools evidently omit the `offset` attribute when 0 for minimization.

For issue https://github.com/sammycage/lunasvg/issues/85.