### PR TITLE
Make library output variable settable in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if(LUNASVG_BUILD_EXAMPLES)
     add_subdirectory(example)
 endif()
 
-set(LUNASVG_LIBDIR ${CMAKE_INSTALL_PREFIX}/lib)
+set(LUNASVG_LIBDIR ${CMAKE_INSTALL_PREFIX}/lib CACHE PATH "library output directory")
 set(LUNASVG_INCDIR ${CMAKE_INSTALL_PREFIX}/include)
 
 install(FILES


### PR DESCRIPTION
Hey, I'm trying to package moneymanagerex in Fedora and also packaging this as a dependency. `LUNASVG_LIBDIR` needs to be settable from the command line because `lib64` is needed as an output directory. I created a patch in the specfile but I should also get the patch [merged upstream if possible](https://docs.fedoraproject.org/en-US/packaging-guidelines/PatchUpstreamStatus/#_all_patches_should_have_an_upstream_bug_link_or_comment). 🙂  Thanks!