### PR TITLE
Add soversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,10 @@ add_subdirectory(3rdparty/plutovg)
 if(BUILD_SHARED_LIBS)
     target_compile_definitions(lunasvg PUBLIC LUNASVG_SHARED)
     target_compile_definitions(lunasvg PRIVATE LUNASVG_EXPORT)
+    set_target_properties(lunasvg PROPERTIES
+      VERSION ${PROJECT_VERSION}
+      SOVERSION ${PROJECT_VERSION_MAJOR}
+    )
 endif()
 
 if(LUNASVG_BUILD_EXAMPLES)


### PR DESCRIPTION
Also, a soversion [must be added to a shared library](https://docs.fedoraproject.org/en-US/packaging-guidelines/#_devel_packages) in order to be packaged. This would do a soversion of 2, because the major version of the project release is 2.