### PR TITLE
Fix undefined behavior caused by a domain error on an sqrt call.

### DIFF
--- a/3rdparty/plutovg/plutovg-blend.c
+++ b/3rdparty/plutovg/plutovg-blend.c
@@ -2,6 +2,7 @@
 
 #include <limits.h>
 #include <math.h>
+#include <float.h>
 
 #define COLOR_TABLE_SIZE 1024
 typedef struct {
@@ -243,6 +244,7 @@ static void fetch_radial_gradient(uint32_t* buffer, const radial_gradient_values
         while(buffer < end)
         {
             uint32_t result = 0;
+            det = fabs(det) < DBL_EPSILON ? 0.0 : det;
             if(det >= 0)
             {
                 double w = sqrt(det) - b;
@@ -261,7 +263,11 @@ static void fetch_radial_gradient(uint32_t* buffer, const radial_gradient_values
     {
         while(buffer < end)
         {
-            *buffer++ = gradient_pixel(gradient, sqrt(det) - b);
+            det = fabs(det) < DBL_EPSILON ? 0.0 : det;
+            uint32_t result = 0;
+            if (det >= 0)
+                result = gradient_pixel(gradient, sqrt(det) - b);
+            *buffer++ = result;
             det += delta_det;
             delta_det += delta_delta_det;
             b += delta_b;


### PR DESCRIPTION
This PR is a follow-up of #121. 

**Issue:**

A call on `sqrt` on a negative number caused it to return a `-nan`, and then it was casted to an integer, triggering undefined behavior.

**Test Case:**

https://user-images.githubusercontent.com/3461126/225024410-286b1073-7d19-41b9-8c26-7641abe72579.svg

**Fix:**

The sqrt call is only performed on zero or positive values. 

-------------------------------

@sammycage Thanks for pointing out that I had forgotten to initialize `result` with a default value in case we must skip the computation. If zero is checked without a threshold, we can introduce defects into the generated image (using my test case). That is why I added `fabs(det) < DBL_EPSILON ? 0.0`.


Best regards,
Manuel.
