### PR TITLE
[lunasvg] Add cmake usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,10 @@ install(FILES
 )
 
 install(TARGETS lunasvg
-    LIBRARY     DESTINATION    ${LUNASVG_LIBDIR}
-    ARCHIVE     DESTINATION    ${LUNASVG_LIBDIR}
-    INCLUDES    DESTINATION    ${LUNASVG_INCDIR}
-)
+    EXPORT lunasvg-config
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    PUBLIC_HEADER DESTINATION include)
+
+install(EXPORT lunasvg-config NAMESPACE lunasvg:: DESTINATION share/lunasvg)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_include_directories(lunasvg
 PUBLIC
-    "${CMAKE_CURRENT_LIST_DIR}"
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
+    $<INSTALL_INTERFACE:include>
 )


### PR DESCRIPTION
Related issue https://github.com/microsoft/vcpkg/pull/30196, unasvg does not export anything after installation, Add usage for port lunasvg.
Tested the usage via vcpkg successfully by lunasvg:x64-windows:
````
lunasvg provides CMake targets:

    # this is heuristically generated, and may not be correct
    find_package(unofficial-lunasvg CONFIG REQUIRED)
    target_link_libraries(main PRIVATE unofficial::lunasvg::lunasvg)
````