### PR TITLE
Fixed incorrect INSTALL_INTERFACE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,12 @@ install(FILES
 )
 
 install(TARGETS lunasvg
+    EXPORT lunasvg-config
     LIBRARY     DESTINATION    ${LUNASVG_LIBDIR}
     ARCHIVE     DESTINATION    ${LUNASVG_LIBDIR}
     INCLUDES    DESTINATION    ${LUNASVG_INCDIR}
+)
+install(EXPORT lunasvg-config
+    DESTINATION ${LUNASVG_LIBDIR}/cmake/lunasvg
+    NAMESPACE lunasvg::
 )

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,4 +1,12 @@
 target_include_directories(lunasvg
 PUBLIC
-    "${CMAKE_CURRENT_LIST_DIR}"
+    # When building a project that uses the lunasvg library,
+    # we need to look in the installed include directory
+    $<INSTALL_INTERFACE:include>
+
+    # When building the lunasvg library we need to look in the
+    # build dir for the lunasvg_export.h header and in the source
+    # dir for other headers
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BUILD_DIR}>
 )


### PR DESCRIPTION
Related #132

I'm using lunasvg in [opensim-creator](https://github.com/ComputationalBiomechanicsLab/opensim-creator), which is a cross-platform app for Linux, Mac, and Windows.

Lunasvg works great, but I am finding (similar to #132) that the installed CMake target cannot locate the installed header files etc.. I generally have to patch each lunasvg with this changeset in order to get things working on my target platforms.

I don't know if this is the best approach for it--this is just a suggestion--and I don't have any expectations w.r.t. changes, timelines, etc. - this is just an idea that would be handy for me if considered, because it would mean I don't need to manually add this changeset to each lunasvg release whenever I get around to updating my dependencies.