### PR TITLE
rename inner selector in seletor to subselector

### DIFF
--- a/source/parser.cpp
+++ b/source/parser.cpp
@@ -1226,8 +1226,8 @@ bool RuleData::matchPseudoClassSelector(const PseudoClassSelector& selector, con
         return element->parent == nullptr;
 
     if(selector.type == PseudoClassSelector::Type::Is) {
-        for(auto& selector : selector.subSelectors) {
-            for(auto& sel : selector) {
+        for(auto& subselector : selector.subSelectors) {
+            for(auto& sel : subselector) {
                 if(!matchSimpleSelector(sel, element)) {
                     return false;
                 }
@@ -1238,8 +1238,8 @@ bool RuleData::matchPseudoClassSelector(const PseudoClassSelector& selector, con
     }
 
     if(selector.type == PseudoClassSelector::Type::Not) {
-        for(auto& selector : selector.subSelectors) {
-            for(auto& sel : selector) {
+        for(auto& subselector : selector.subSelectors) {
+            for(auto& sel : subselector) {
                 if(matchSimpleSelector(sel, element)) {
                     return false;
                 }


### PR DESCRIPTION
Thank you for relaxing compiler requirements on lunasvg/2.3.9.

I met compilation error on gcc 5.4.0.
```
source/parser.cpp: In static member function ‘static bool lunasvg::RuleData::matchPseudoClassSelector(const lunasvg::PseudoClassSelector&, const lunasvg::Element*)’:
source/parser.cpp:1229:30: error: use of ‘selector’ before deduction of ‘auto’
         for(auto& selector : selector.subSelectors) {
                              ^
source/parser.cpp:1230:29: error: unable to deduce ‘auto&&’ from ‘selector’
             for(auto& sel : selector) {
                             ^
source/parser.cpp:1241:30: error: use of ‘selector’ before deduction of ‘auto’
         for(auto& selector : selector.subSelectors) {
                              ^
source/parser.cpp:1242:29: error: unable to deduce ‘auto&&’ from ‘selector’
             for(auto& sel : selector) {
                             ^
```

Those errors are caused by same symbol name in for loops.
If possible, woudl you merge this PR to work well on old gcc compilers.

