### PR TITLE
Create folder containing C++ version of plutovg

### DIFF
--- a/source/plutovg/FTL.TXT
+++ b/source/plutovg/FTL.TXT
@@ -1,0 +1,166 @@
+                    The FreeType Project LICENSE
+                    ----------------------------
+
+                            2006-Jan-27
+
+                    Copyright 1996-2002, 2006 by
+          David Turner, Robert Wilhelm, and Werner Lemberg
+
+
+
+Introduction
+============
+
+  The FreeType  Project is distributed in  several archive packages;
+  some of them may contain, in addition to the FreeType font engine,
+  various tools and  contributions which rely on, or  relate to, the
+  FreeType Project.
+
+  This  license applies  to all  files found  in such  packages, and
+  which do not  fall under their own explicit  license.  The license
+  affects  thus  the  FreeType   font  engine,  the  test  programs,
+  documentation and makefiles, at the very least.
+
+  This  license   was  inspired  by  the  BSD,   Artistic,  and  IJG
+  (Independent JPEG  Group) licenses, which  all encourage inclusion
+  and  use of  free  software in  commercial  and freeware  products
+  alike.  As a consequence, its main points are that:
+
+    o We don't promise that this software works. However, we will be
+      interested in any kind of bug reports. (`as is' distribution)
+
+    o You can  use this software for whatever you  want, in parts or
+      full form, without having to pay us. (`royalty-free' usage)
+
+    o You may not pretend that  you wrote this software.  If you use
+      it, or  only parts of it,  in a program,  you must acknowledge
+      somewhere  in  your  documentation  that  you  have  used  the
+      FreeType code. (`credits')
+
+  We  specifically  permit  and  encourage  the  inclusion  of  this
+  software, with  or without modifications,  in commercial products.
+  We  disclaim  all warranties  covering  The  FreeType Project  and
+  assume no liability related to The FreeType Project.
+
+
+  Finally,  many  people  asked  us  for  a  preferred  form  for  a
+  credit/disclaimer to use in compliance with this license.  We thus
+  encourage you to use the following text:
+
+   """
+    Portions of this software are copyright � <year> The FreeType
+    Project (www.freetype.org).  All rights reserved.
+   """
+
+  Please replace <year> with the value from the FreeType version you
+  actually use.
+
+
+Legal Terms
+===========
+
+0. Definitions
+--------------
+
+  Throughout this license,  the terms `package', `FreeType Project',
+  and  `FreeType  archive' refer  to  the  set  of files  originally
+  distributed  by the  authors  (David Turner,  Robert Wilhelm,  and
+  Werner Lemberg) as the `FreeType Project', be they named as alpha,
+  beta or final release.
+
+  `You' refers to  the licensee, or person using  the project, where
+  `using' is a generic term including compiling the project's source
+  code as  well as linking it  to form a  `program' or `executable'.
+  This  program is  referred to  as  `a program  using the  FreeType
+  engine'.
+
+  This  license applies  to all  files distributed  in  the original
+  FreeType  Project,   including  all  source   code,  binaries  and
+  documentation,  unless  otherwise  stated   in  the  file  in  its
+  original, unmodified form as  distributed in the original archive.
+  If you are  unsure whether or not a particular  file is covered by
+  this license, you must contact us to verify this.
+
+  The FreeType  Project is copyright (C) 1996-2000  by David Turner,
+  Robert Wilhelm, and Werner Lemberg.  All rights reserved except as
+  specified below.
+
+1. No Warranty
+--------------
+
+  THE FREETYPE PROJECT  IS PROVIDED `AS IS' WITHOUT  WARRANTY OF ANY
+  KIND, EITHER  EXPRESS OR IMPLIED,  INCLUDING, BUT NOT  LIMITED TO,
+  WARRANTIES  OF  MERCHANTABILITY   AND  FITNESS  FOR  A  PARTICULAR
+  PURPOSE.  IN NO EVENT WILL ANY OF THE AUTHORS OR COPYRIGHT HOLDERS
+  BE LIABLE  FOR ANY DAMAGES CAUSED  BY THE USE OR  THE INABILITY TO
+  USE, OF THE FREETYPE PROJECT.
+
+2. Redistribution
+-----------------
+
+  This  license  grants  a  worldwide, royalty-free,  perpetual  and
+  irrevocable right  and license to use,  execute, perform, compile,
+  display,  copy,   create  derivative  works   of,  distribute  and
+  sublicense the  FreeType Project (in  both source and  object code
+  forms)  and  derivative works  thereof  for  any  purpose; and  to
+  authorize others  to exercise  some or all  of the  rights granted
+  herein, subject to the following conditions:
+
+    o Redistribution of  source code  must retain this  license file
+      (`FTL.TXT') unaltered; any  additions, deletions or changes to
+      the original  files must be clearly  indicated in accompanying
+      documentation.   The  copyright   notices  of  the  unaltered,
+      original  files must  be  preserved in  all  copies of  source
+      files.
+
+    o Redistribution in binary form must provide a  disclaimer  that
+      states  that  the software is based in part of the work of the
+      FreeType Team,  in  the  distribution  documentation.  We also
+      encourage you to put an URL to the FreeType web page  in  your
+      documentation, though this isn't mandatory.
+
+  These conditions  apply to any  software derived from or  based on
+  the FreeType Project,  not just the unmodified files.   If you use
+  our work, you  must acknowledge us.  However, no  fee need be paid
+  to us.
+
+3. Advertising
+--------------
+
+  Neither the  FreeType authors and  contributors nor you  shall use
+  the name of the  other for commercial, advertising, or promotional
+  purposes without specific prior written permission.
+
+  We suggest,  but do not require, that  you use one or  more of the
+  following phrases to refer  to this software in your documentation
+  or advertising  materials: `FreeType Project',  `FreeType Engine',
+  `FreeType library', or `FreeType Distribution'.
+
+  As  you have  not signed  this license,  you are  not  required to
+  accept  it.   However,  as  the FreeType  Project  is  copyrighted
+  material, only  this license, or  another one contracted  with the
+  authors, grants you  the right to use, distribute,  and modify it.
+  Therefore,  by  using,  distributing,  or modifying  the  FreeType
+  Project, you indicate that you understand and accept all the terms
+  of this license.
+
+4. Contacts
+-----------
+
+  There are two mailing lists related to FreeType:
+
+    o freetype@nongnu.org
+
+      Discusses general use and applications of FreeType, as well as
+      future and  wanted additions to the  library and distribution.
+      If  you are looking  for support,  start in  this list  if you
+      haven't found anything to help you in the documentation.
+
+    o freetype-devel@nongnu.org
+
+      Discusses bugs,  as well  as engine internals,  design issues,
+      specific licenses, porting, etc.
+
+  Our home page can be found at
+
+    http://www.freetype.org

--- a/source/plutovg/plutovg-blend.cpp
+++ b/source/plutovg/plutovg-blend.cpp
@@ -1,5 +1,6 @@
 #include "plutovg-private.h"
 
+#include <cstring>
 #include <float.h>
 #include <limits.h>
 #include <math.h>

--- a/source/plutovg/plutovg-blend.cpp
+++ b/source/plutovg/plutovg-blend.cpp
@@ -1,0 +1,847 @@
+#include "plutovg-private.h"
+
+#include <float.h>
+#include <limits.h>
+#include <math.h>
+#include <stdint.h>
+
+#define COLOR_TABLE_SIZE 1024
+typedef struct
+{
+    plutovg_spread_method_t spread;
+    plutovg_matrix_t matrix;
+    uint32_t colortable[COLOR_TABLE_SIZE];
+    union
+    {
+        struct
+        {
+            double x1, y1;
+            double x2, y2;
+        } linear;
+        struct
+        {
+            double cx, cy, cr;
+            double fx, fy, fr;
+        } radial;
+    };
+} gradient_data_t;
+
+typedef struct
+{
+    plutovg_matrix_t matrix;
+    uint8_t* data;
+    int width;
+    int height;
+    int stride;
+    int const_alpha;
+} texture_data_t;
+
+typedef struct
+{
+    double dx;
+    double dy;
+    double l;
+    double off;
+} linear_gradient_values_t;
+
+typedef struct
+{
+    double dx;
+    double dy;
+    double dr;
+    double sqrfr;
+    double a;
+    double inv2a;
+    int extended;
+} radial_gradient_values_t;
+
+static inline uint32_t premultiply_color(const plutovg_color_t* color, double opacity)
+{
+    uint32_t alpha = (uint8_t) (color->a * opacity * 255);
+    uint32_t pr = (uint8_t) (color->r * alpha);
+    uint32_t pg = (uint8_t) (color->g * alpha);
+    uint32_t pb = (uint8_t) (color->b * alpha);
+
+    return (alpha << 24) | (pr << 16) | (pg << 8) | (pb);
+}
+
+static inline uint32_t combine_opacity(const plutovg_color_t* color, double opacity)
+{
+    uint32_t a = (uint8_t) (color->a * opacity * 255);
+    uint32_t r = (uint8_t) (color->r * 255);
+    uint32_t g = (uint8_t) (color->g * 255);
+    uint32_t b = (uint8_t) (color->b * 255);
+
+    return (a << 24) | (r << 16) | (g << 8) | (b);
+}
+
+static inline uint32_t premultiply_pixel(uint32_t color)
+{
+    uint32_t a = plutovg_alpha(color);
+    uint32_t r = plutovg_red(color);
+    uint32_t g = plutovg_green(color);
+    uint32_t b = plutovg_blue(color);
+
+    uint32_t pr = (r * a) / 255;
+    uint32_t pg = (g * a) / 255;
+    uint32_t pb = (b * a) / 255;
+    return (a << 24) | (pr << 16) | (pg << 8) | (pb);
+}
+
+static inline uint32_t interpolate_pixel(uint32_t x, uint32_t a, uint32_t y, uint32_t b)
+{
+    uint32_t t = (x & 0xff00ff) * a + (y & 0xff00ff) * b;
+    t = (t + ((t >> 8) & 0xff00ff) + 0x800080) >> 8;
+    t &= 0xff00ff;
+    x = ((x >> 8) & 0xff00ff) * a + ((y >> 8) & 0xff00ff) * b;
+    x = (x + ((x >> 8) & 0xff00ff) + 0x800080);
+    x &= 0xff00ff00;
+    x |= t;
+    return x;
+}
+
+static inline uint32_t BYTE_MUL(uint32_t x, uint32_t a)
+{
+    uint32_t t = (x & 0xff00ff) * a;
+    t = (t + ((t >> 8) & 0xff00ff) + 0x800080) >> 8;
+    t &= 0xff00ff;
+    x = ((x >> 8) & 0xff00ff) * a;
+    x = (x + ((x >> 8) & 0xff00ff) + 0x800080);
+    x &= 0xff00ff00;
+    x |= t;
+    return x;
+}
+
+static inline void memfill32(uint32_t* dest, uint32_t value, int length)
+{
+    for (int i = 0; i < length; i++)
+        dest[i] = value;
+}
+
+static inline int gradient_clamp(const gradient_data_t* gradient, int ipos)
+{
+    if (gradient->spread == plutovg_spread_method_repeat)
+    {
+        ipos = ipos % COLOR_TABLE_SIZE;
+        ipos = ipos < 0 ? COLOR_TABLE_SIZE + ipos : ipos;
+    }
+    else if (gradient->spread == plutovg_spread_method_reflect)
+    {
+        const int limit = COLOR_TABLE_SIZE * 2;
+        ipos = ipos % limit;
+        ipos = ipos < 0 ? limit + ipos : ipos;
+        ipos = ipos >= COLOR_TABLE_SIZE ? limit - 1 - ipos : ipos;
+    }
+    else
+    {
+        if (ipos < 0)
+            ipos = 0;
+        else if (ipos >= COLOR_TABLE_SIZE)
+            ipos = COLOR_TABLE_SIZE - 1;
+    }
+
+    return ipos;
+}
+
+#define FIXPT_BITS 8
+#define FIXPT_SIZE (1 << FIXPT_BITS)
+static inline uint32_t gradient_pixel_fixed(const gradient_data_t* gradient, int fixed_pos)
+{
+    int ipos = (fixed_pos + (FIXPT_SIZE / 2)) >> FIXPT_BITS;
+    return gradient->colortable[gradient_clamp(gradient, ipos)];
+}
+
+static inline uint32_t gradient_pixel(const gradient_data_t* gradient, double pos)
+{
+    int ipos = (int) (pos * (COLOR_TABLE_SIZE - 1) + 0.5);
+    return gradient->colortable[gradient_clamp(gradient, ipos)];
+}
+
+static void fetch_linear_gradient(uint32_t* buffer, const linear_gradient_values_t* v, const gradient_data_t* gradient,
+                                  int y, int x, int length)
+{
+    double t, inc;
+    double rx = 0, ry = 0;
+
+    if (v->l == 0.0)
+    {
+        t = inc = 0;
+    }
+    else
+    {
+        rx = gradient->matrix.m01 * (y + 0.5) + gradient->matrix.m00 * (x + 0.5) + gradient->matrix.m02;
+        ry = gradient->matrix.m11 * (y + 0.5) + gradient->matrix.m10 * (x + 0.5) + gradient->matrix.m12;
+        t = v->dx * rx + v->dy * ry + v->off;
+        inc = v->dx * gradient->matrix.m00 + v->dy * gradient->matrix.m10;
+        t *= (COLOR_TABLE_SIZE - 1);
+        inc *= (COLOR_TABLE_SIZE - 1);
+    }
+
+    const uint32_t* end = buffer + length;
+    if (inc > -1e-5 && inc < 1e-5)
+    {
+        memfill32(buffer, gradient_pixel_fixed(gradient, (int) (t * FIXPT_SIZE)), length);
+    }
+    else
+    {
+        if (t + inc * length < (double) (INT_MAX >> (FIXPT_BITS + 1)) &&
+            t + inc * length > (double) (INT_MIN >> (FIXPT_BITS + 1)))
+        {
+            int t_fixed = (int) (t * FIXPT_SIZE);
+            int inc_fixed = (int) (inc * FIXPT_SIZE);
+            while (buffer < end)
+            {
+                *buffer = gradient_pixel_fixed(gradient, t_fixed);
+                t_fixed += inc_fixed;
+                ++buffer;
+            }
+        }
+        else
+        {
+            while (buffer < end)
+            {
+                *buffer = gradient_pixel(gradient, t / COLOR_TABLE_SIZE);
+                t += inc;
+                ++buffer;
+            }
+        }
+    }
+}
+
+static void fetch_radial_gradient(uint32_t* buffer, const radial_gradient_values_t* v, const gradient_data_t* gradient,
+                                  int y, int x, int length)
+{
+    if (v->a == 0.0)
+    {
+        memfill32(buffer, 0, length);
+        return;
+    }
+
+    double rx = gradient->matrix.m01 * (y + 0.5) + gradient->matrix.m02 + gradient->matrix.m00 * (x + 0.5);
+    double ry = gradient->matrix.m11 * (y + 0.5) + gradient->matrix.m12 + gradient->matrix.m10 * (x + 0.5);
+
+    rx -= gradient->radial.fx;
+    ry -= gradient->radial.fy;
+
+    double inv_a = 1 / (2 * v->a);
+    double delta_rx = gradient->matrix.m00;
+    double delta_ry = gradient->matrix.m10;
+
+    double b = 2 * (v->dr * gradient->radial.fr + rx * v->dx + ry * v->dy);
+    double delta_b = 2 * (delta_rx * v->dx + delta_ry * v->dy);
+    double b_delta_b = 2 * b * delta_b;
+    double delta_b_delta_b = 2 * delta_b * delta_b;
+
+    double bb = b * b;
+    double delta_bb = delta_b * delta_b;
+
+    b *= inv_a;
+    delta_b *= inv_a;
+
+    double rxrxryry = rx * rx + ry * ry;
+    double delta_rxrxryry = delta_rx * delta_rx + delta_ry * delta_ry;
+    double rx_plus_ry = 2 * (rx * delta_rx + ry * delta_ry);
+    double delta_rx_plus_ry = 2 * delta_rxrxryry;
+
+    inv_a *= inv_a;
+
+    double det = (bb - 4 * v->a * (v->sqrfr - rxrxryry)) * inv_a;
+    double delta_det = (b_delta_b + delta_bb + 4 * v->a * (rx_plus_ry + delta_rxrxryry)) * inv_a;
+    double delta_delta_det = (delta_b_delta_b + 4 * v->a * delta_rx_plus_ry) * inv_a;
+
+    const uint32_t* end = buffer + length;
+    if (v->extended)
+    {
+        while (buffer < end)
+        {
+            uint32_t result = 0;
+            det = fabs(det) < DBL_EPSILON ? 0.0 : det;
+            if (det >= 0)
+            {
+                double w = sqrt(det) - b;
+                if (gradient->radial.fr + v->dr * w >= 0)
+                    result = gradient_pixel(gradient, w);
+            }
+
+            *buffer = result;
+            det += delta_det;
+            delta_det += delta_delta_det;
+            b += delta_b;
+            ++buffer;
+        }
+    }
+    else
+    {
+        while (buffer < end)
+        {
+            det = fabs(det) < DBL_EPSILON ? 0.0 : det;
+            uint32_t result = 0;
+            if (det >= 0)
+                result = gradient_pixel(gradient, sqrt(det) - b);
+            *buffer++ = result;
+            det += delta_det;
+            delta_det += delta_delta_det;
+            b += delta_b;
+        }
+    }
+}
+
+static void composition_solid_source(uint32_t* dest, int length, uint32_t color, uint32_t alpha)
+{
+    if (alpha == 255)
+    {
+        memfill32(dest, color, length);
+    }
+    else
+    {
+        uint32_t ialpha = 255 - alpha;
+        color = BYTE_MUL(color, alpha);
+        for (int i = 0; i < length; i++)
+            dest[i] = color + BYTE_MUL(dest[i], ialpha);
+    }
+}
+
+static void composition_solid_source_over(uint32_t* dest, int length, uint32_t color, uint32_t const_alpha)
+{
+    if (const_alpha != 255)
+        color = BYTE_MUL(color, const_alpha);
+    uint32_t ialpha = 255 - plutovg_alpha(color);
+    for (int i = 0; i < length; i++)
+        dest[i] = color + BYTE_MUL(dest[i], ialpha);
+}
+
+static void composition_solid_destination_in(uint32_t* dest, int length, uint32_t color, uint32_t const_alpha)
+{
+    uint32_t a = plutovg_alpha(color);
+    if (const_alpha != 255)
+        a = BYTE_MUL(a, const_alpha) + 255 - const_alpha;
+    for (int i = 0; i < length; i++)
+        dest[i] = BYTE_MUL(dest[i], a);
+}
+
+static void composition_solid_destination_out(uint32_t* dest, int length, uint32_t color, uint32_t const_alpha)
+{
+    uint32_t a = plutovg_alpha(~color);
+    if (const_alpha != 255)
+        a = BYTE_MUL(a, const_alpha) + 255 - const_alpha;
+    for (int i = 0; i < length; i++)
+        dest[i] = BYTE_MUL(dest[i], a);
+}
+
+static void composition_source(uint32_t* dest, int length, const uint32_t* src, uint32_t const_alpha)
+{
+    if (const_alpha == 255)
+    {
+        memcpy(dest, src, (size_t) (length) * sizeof(uint32_t));
+    }
+    else
+    {
+        uint32_t ialpha = 255 - const_alpha;
+        for (int i = 0; i < length; i++)
+            dest[i] = interpolate_pixel(src[i], const_alpha, dest[i], ialpha);
+    }
+}
+
+static void composition_source_over(uint32_t* dest, int length, const uint32_t* src, uint32_t const_alpha)
+{
+    uint32_t s, sia;
+    if (const_alpha == 255)
+    {
+        for (int i = 0; i < length; i++)
+        {
+            s = src[i];
+            if (s >= 0xff000000)
+                dest[i] = s;
+            else if (s != 0)
+            {
+                sia = plutovg_alpha(~s);
+                dest[i] = s + BYTE_MUL(dest[i], sia);
+            }
+        }
+    }
+    else
+    {
+        for (int i = 0; i < length; i++)
+        {
+            s = BYTE_MUL(src[i], const_alpha);
+            sia = plutovg_alpha(~s);
+            dest[i] = s + BYTE_MUL(dest[i], sia);
+        }
+    }
+}
+
+static void composition_destination_in(uint32_t* dest, int length, const uint32_t* src, uint32_t const_alpha)
+{
+    if (const_alpha == 255)
+    {
+        for (int i = 0; i < length; i++)
+            dest[i] = BYTE_MUL(dest[i], plutovg_alpha(src[i]));
+    }
+    else
+    {
+        uint32_t cia = 255 - const_alpha;
+        uint32_t a;
+        for (int i = 0; i < length; i++)
+        {
+            a = BYTE_MUL(plutovg_alpha(src[i]), const_alpha) + cia;
+            dest[i] = BYTE_MUL(dest[i], a);
+        }
+    }
+}
+
+static void composition_destination_out(uint32_t* dest, int length, const uint32_t* src, uint32_t const_alpha)
+{
+    if (const_alpha == 255)
+    {
+        for (int i = 0; i < length; i++)
+            dest[i] = BYTE_MUL(dest[i], plutovg_alpha(~src[i]));
+    }
+    else
+    {
+        uint32_t cia = 255 - const_alpha;
+        uint32_t sia;
+        for (int i = 0; i < length; i++)
+        {
+            sia = BYTE_MUL(plutovg_alpha(~src[i]), const_alpha) + cia;
+            dest[i] = BYTE_MUL(dest[i], sia);
+        }
+    }
+}
+
+typedef void (*composition_solid_function_t)(uint32_t* dest, int length, uint32_t color, uint32_t const_alpha);
+typedef void (*composition_function_t)(uint32_t* dest, int length, const uint32_t* src, uint32_t const_alpha);
+
+static const composition_solid_function_t composition_solid_map[] = { composition_solid_source,
+                                                                      composition_solid_source_over,
+                                                                      composition_solid_destination_in,
+                                                                      composition_solid_destination_out };
+
+static const composition_function_t composition_map[] = { composition_source, composition_source_over,
+                                                          composition_destination_in, composition_destination_out };
+
+static void blend_solid(plutovg_surface_t* surface, plutovg_operator_t op, const plutovg_rle_t* rle, uint32_t solid)
+{
+    composition_solid_function_t func = composition_solid_map[op];
+    int count = rle->spans.size;
+    const plutovg_span_t* spans = rle->spans.data;
+    while (count--)
+    {
+        uint32_t* target = (uint32_t*) (surface->data + spans->y * surface->stride) + spans->x;
+        func(target, spans->len, solid, spans->coverage);
+        ++spans;
+    }
+}
+
+#define BUFFER_SIZE 1024
+static void blend_linear_gradient(plutovg_surface_t* surface, plutovg_operator_t op, const plutovg_rle_t* rle,
+                                  const gradient_data_t* gradient)
+{
+    composition_function_t func = composition_map[op];
+    unsigned int buffer[BUFFER_SIZE];
+
+    linear_gradient_values_t v;
+    v.dx = gradient->linear.x2 - gradient->linear.x1;
+    v.dy = gradient->linear.y2 - gradient->linear.y1;
+    v.l = v.dx * v.dx + v.dy * v.dy;
+    v.off = 0.0;
+    if (v.l != 0.0)
+    {
+        v.dx /= v.l;
+        v.dy /= v.l;
+        v.off = -v.dx * gradient->linear.x1 - v.dy * gradient->linear.y1;
+    }
+
+    int count = rle->spans.size;
+    const plutovg_span_t* spans = rle->spans.data;
+    while (count--)
+    {
+        int length = spans->len;
+        int x = spans->x;
+        while (length)
+        {
+            int l = plutovg_min(length, BUFFER_SIZE);
+            fetch_linear_gradient(buffer, &v, gradient, spans->y, x, l);
+            uint32_t* target = (uint32_t*) (surface->data + spans->y * surface->stride) + x;
+            func(target, l, buffer, spans->coverage);
+            x += l;
+            length -= l;
+        }
+
+        ++spans;
+    }
+}
+
+static void blend_radial_gradient(plutovg_surface_t* surface, plutovg_operator_t op, const plutovg_rle_t* rle,
+                                  const gradient_data_t* gradient)
+{
+    composition_function_t func = composition_map[op];
+    unsigned int buffer[BUFFER_SIZE];
+
+    radial_gradient_values_t v;
+    v.dx = gradient->radial.cx - gradient->radial.fx;
+    v.dy = gradient->radial.cy - gradient->radial.fy;
+    v.dr = gradient->radial.cr - gradient->radial.fr;
+    v.sqrfr = gradient->radial.fr * gradient->radial.fr;
+    v.a = v.dr * v.dr - v.dx * v.dx - v.dy * v.dy;
+    v.inv2a = 1.0 / (2.0 * v.a);
+    v.extended = gradient->radial.fr != 0.0 || v.a <= 0.0;
+
+    int count = rle->spans.size;
+    const plutovg_span_t* spans = rle->spans.data;
+    while (count--)
+    {
+        int length = spans->len;
+        int x = spans->x;
+        while (length)
+        {
+            int l = plutovg_min(length, BUFFER_SIZE);
+            fetch_radial_gradient(buffer, &v, gradient, spans->y, x, l);
+            uint32_t* target = (uint32_t*) (surface->data + spans->y * surface->stride) + x;
+            func(target, l, buffer, spans->coverage);
+            x += l;
+            length -= l;
+        }
+
+        ++spans;
+    }
+}
+
+#define FIXED_SCALE (1 << 16)
+static void blend_transformed_argb(plutovg_surface_t* surface, plutovg_operator_t op, const plutovg_rle_t* rle,
+                                   const texture_data_t* texture)
+{
+    composition_function_t func = composition_map[op];
+    uint32_t buffer[BUFFER_SIZE];
+
+    int image_width = texture->width;
+    int image_height = texture->height;
+
+    int fdx = (int) (texture->matrix.m00 * FIXED_SCALE);
+    int fdy = (int) (texture->matrix.m10 * FIXED_SCALE);
+
+    int count = rle->spans.size;
+    const plutovg_span_t* spans = rle->spans.data;
+    while (count--)
+    {
+        uint32_t* target = (uint32_t*) (surface->data + spans->y * surface->stride) + spans->x;
+
+        const double cx = spans->x + 0.5;
+        const double cy = spans->y + 0.5;
+
+        int x = (int) ((texture->matrix.m01 * cy + texture->matrix.m00 * cx + texture->matrix.m02) * FIXED_SCALE);
+        int y = (int) ((texture->matrix.m11 * cy + texture->matrix.m10 * cx + texture->matrix.m12) * FIXED_SCALE);
+
+        int length = spans->len;
+        const int coverage = (spans->coverage * texture->const_alpha) >> 8;
+        while (length)
+        {
+            int l = plutovg_min(length, BUFFER_SIZE);
+            const uint32_t* end = buffer + l;
+            uint32_t* b = buffer;
+            while (b < end)
+            {
+                int px = plutovg_clamp(x >> 16, 0, image_width - 1);
+                int py = plutovg_clamp(y >> 16, 0, image_height - 1);
+                *b = ((const uint32_t*) (texture->data + py * texture->stride))[px];
+
+                x += fdx;
+                y += fdy;
+                ++b;
+            }
+
+            func(target, l, buffer, coverage);
+            target += l;
+            length -= l;
+        }
+
+        ++spans;
+    }
+}
+
+static void blend_untransformed_argb(plutovg_surface_t* surface, plutovg_operator_t op, const plutovg_rle_t* rle,
+                                     const texture_data_t* texture)
+{
+    composition_function_t func = composition_map[op];
+
+    const int image_width = texture->width;
+    const int image_height = texture->height;
+
+    int xoff = (int) (texture->matrix.m02);
+    int yoff = (int) (texture->matrix.m12);
+
+    int count = rle->spans.size;
+    const plutovg_span_t* spans = rle->spans.data;
+    while (count--)
+    {
+        int x = spans->x;
+        int length = spans->len;
+        int sx = xoff + x;
+        int sy = yoff + spans->y;
+        if (sy >= 0 && sy < image_height && sx < image_width)
+        {
+            if (sx < 0)
+            {
+                x -= sx;
+                length += sx;
+                sx = 0;
+            }
+            if (sx + length > image_width)
+                length = image_width - sx;
+            if (length > 0)
+            {
+                const int coverage = (spans->coverage * texture->const_alpha) >> 8;
+                const uint32_t* src = (const uint32_t*) (texture->data + sy * texture->stride) + sx;
+                uint32_t* dest = (uint32_t*) (surface->data + spans->y * surface->stride) + x;
+                func(dest, length, src, coverage);
+            }
+        }
+
+        ++spans;
+    }
+}
+
+static void blend_untransformed_tiled_argb(plutovg_surface_t* surface, plutovg_operator_t op, const plutovg_rle_t* rle,
+                                           const texture_data_t* texture)
+{
+    composition_function_t func = composition_map[op];
+
+    int image_width = texture->width;
+    int image_height = texture->height;
+
+    int xoff = (int) (texture->matrix.m02) % image_width;
+    int yoff = (int) (texture->matrix.m12) % image_height;
+
+    if (xoff < 0)
+        xoff += image_width;
+    if (yoff < 0)
+        yoff += image_height;
+
+    int count = rle->spans.size;
+    const plutovg_span_t* spans = rle->spans.data;
+    while (count--)
+    {
+        int x = spans->x;
+        int length = spans->len;
+        int sx = (xoff + spans->x) % image_width;
+        int sy = (spans->y + yoff) % image_height;
+        if (sx < 0)
+            sx += image_width;
+        if (sy < 0)
+            sy += image_height;
+
+        const int coverage = (spans->coverage * texture->const_alpha) >> 8;
+        while (length)
+        {
+            int l = plutovg_min(image_width - sx, length);
+            if (BUFFER_SIZE < l)
+                l = BUFFER_SIZE;
+            const uint32_t* src = (const uint32_t*) (texture->data + sy * texture->stride) + sx;
+            uint32_t* dest = (uint32_t*) (surface->data + spans->y * surface->stride) + x;
+            func(dest, l, src, coverage);
+            x += l;
+            length -= l;
+            sx = 0;
+        }
+
+        ++spans;
+    }
+}
+
+static void blend_transformed_tiled_argb(plutovg_surface_t* surface, plutovg_operator_t op, const plutovg_rle_t* rle,
+                                         const texture_data_t* texture)
+{
+    composition_function_t func = composition_map[op];
+    uint32_t buffer[BUFFER_SIZE];
+
+    int image_width = texture->width;
+    int image_height = texture->height;
+    const int scanline_offset = texture->stride / 4;
+
+    int fdx = (int) (texture->matrix.m00 * FIXED_SCALE);
+    int fdy = (int) (texture->matrix.m10 * FIXED_SCALE);
+
+    int count = rle->spans.size;
+    const plutovg_span_t* spans = rle->spans.data;
+    while (count--)
+    {
+        uint32_t* target = (uint32_t*) (surface->data + spans->y * surface->stride) + spans->x;
+        const uint32_t* image_bits = (const uint32_t*) texture->data;
+
+        const double cx = spans->x + 0.5;
+        const double cy = spans->y + 0.5;
+
+        int x = (int) ((texture->matrix.m01 * cy + texture->matrix.m00 * cx + texture->matrix.m02) * FIXED_SCALE);
+        int y = (int) ((texture->matrix.m11 * cy + texture->matrix.m10 * cx + texture->matrix.m12) * FIXED_SCALE);
+
+        const int coverage = (spans->coverage * texture->const_alpha) >> 8;
+        int length = spans->len;
+        while (length)
+        {
+            int l = plutovg_min(length, BUFFER_SIZE);
+            const uint32_t* end = buffer + l;
+            uint32_t* b = buffer;
+            int px16 = x % (image_width << 16);
+            int py16 = y % (image_height << 16);
+            int px_delta = fdx % (image_width << 16);
+            int py_delta = fdy % (image_height << 16);
+            while (b < end)
+            {
+                if (px16 < 0)
+                    px16 += image_width << 16;
+                if (py16 < 0)
+                    py16 += image_height << 16;
+                int px = px16 >> 16;
+                int py = py16 >> 16;
+                int y_offset = py * scanline_offset;
+
+                *b = image_bits[y_offset + px];
+                x += fdx;
+                y += fdy;
+                px16 += px_delta;
+                if (px16 >= image_width << 16)
+                    px16 -= image_width << 16;
+                py16 += py_delta;
+                if (py16 >= image_height << 16)
+                    py16 -= image_height << 16;
+                ++b;
+            }
+
+            func(target, l, buffer, coverage);
+            target += l;
+            length -= l;
+        }
+
+        ++spans;
+    }
+}
+
+void plutovg_blend(plutovg_t* pluto, const plutovg_rle_t* rle)
+{
+    plutovg_paint_t* source = &pluto->state->paint;
+    if (source->type == plutovg_paint_type_color)
+        plutovg_blend_color(pluto, rle, &source->color);
+    else if (source->type == plutovg_paint_type_gradient)
+        plutovg_blend_gradient(pluto, rle, &source->gradient);
+    else
+        plutovg_blend_texture(pluto, rle, &source->texture);
+}
+
+void plutovg_blend_color(plutovg_t* pluto, const plutovg_rle_t* rle, const plutovg_color_t* color)
+{
+    plutovg_state_t* state = pluto->state;
+    uint32_t solid = premultiply_color(color, state->opacity);
+
+    uint32_t alpha = plutovg_alpha(solid);
+    if (alpha == 255 && state->op == plutovg_operator_src_over)
+        blend_solid(pluto->surface, plutovg_operator_src, rle, solid);
+    else
+        blend_solid(pluto->surface, state->op, rle, solid);
+}
+
+void plutovg_blend_gradient(plutovg_t* pluto, const plutovg_rle_t* rle, const plutovg_gradient_t* gradient)
+{
+    plutovg_state_t* state = pluto->state;
+    gradient_data_t data;
+    int i, pos = 0, nstop = gradient->stops.size;
+    const plutovg_gradient_stop_t *curr, *next, *start, *last;
+    uint32_t curr_color, next_color, last_color;
+    uint32_t dist, idist;
+    double delta, t, incr, fpos;
+    double opacity = state->opacity * gradient->opacity;
+
+    start = gradient->stops.data;
+    curr = start;
+    curr_color = combine_opacity(&curr->color, opacity);
+
+    data.colortable[pos] = premultiply_pixel(curr_color);
+    ++pos;
+    incr = 1.0 / COLOR_TABLE_SIZE;
+    fpos = 1.5 * incr;
+
+    while (fpos <= curr->offset)
+    {
+        data.colortable[pos] = data.colortable[pos - 1];
+        ++pos;
+        fpos += incr;
+    }
+
+    for (i = 0; i < nstop - 1; i++)
+    {
+        curr = (start + i);
+        next = (start + i + 1);
+        delta = 1.0 / (next->offset - curr->offset);
+        next_color = combine_opacity(&next->color, opacity);
+        while (fpos < next->offset && pos < COLOR_TABLE_SIZE)
+        {
+            t = (fpos - curr->offset) * delta;
+            dist = (uint32_t) (255 * t);
+            idist = 255 - dist;
+            data.colortable[pos] = premultiply_pixel(interpolate_pixel(curr_color, idist, next_color, dist));
+            ++pos;
+            fpos += incr;
+        }
+
+        curr_color = next_color;
+    }
+
+    last = start + nstop - 1;
+    last_color = premultiply_color(&last->color, opacity);
+    for (; pos < COLOR_TABLE_SIZE; ++pos)
+        data.colortable[pos] = last_color;
+
+    data.spread = gradient->spread;
+    data.matrix = gradient->matrix;
+    plutovg_matrix_multiply(&data.matrix, &data.matrix, &state->matrix);
+    plutovg_matrix_invert(&data.matrix);
+
+    if (gradient->type == plutovg_gradient_type_linear)
+    {
+        data.linear.x1 = gradient->values[0];
+        data.linear.y1 = gradient->values[1];
+        data.linear.x2 = gradient->values[2];
+        data.linear.y2 = gradient->values[3];
+        blend_linear_gradient(pluto->surface, state->op, rle, &data);
+    }
+    else
+    {
+        data.radial.cx = gradient->values[0];
+        data.radial.cy = gradient->values[1];
+        data.radial.cr = gradient->values[2];
+        data.radial.fx = gradient->values[3];
+        data.radial.fy = gradient->values[4];
+        data.radial.fr = gradient->values[5];
+        blend_radial_gradient(pluto->surface, state->op, rle, &data);
+    }
+}
+
+void plutovg_blend_texture(plutovg_t* pluto, const plutovg_rle_t* rle, const plutovg_texture_t* texture)
+{
+    plutovg_state_t* state = pluto->state;
+    texture_data_t data;
+    data.data = texture->surface->data;
+    data.width = texture->surface->width;
+    data.height = texture->surface->height;
+    data.stride = texture->surface->stride;
+    data.const_alpha = (int) (state->opacity * texture->opacity * 256.0);
+
+    data.matrix = texture->matrix;
+    plutovg_matrix_multiply(&data.matrix, &data.matrix, &state->matrix);
+    plutovg_matrix_invert(&data.matrix);
+
+    const plutovg_matrix_t* matrix = &data.matrix;
+    int translating = (matrix->m00 == 1.0 && matrix->m10 == 0.0 && matrix->m01 == 0.0 && matrix->m11 == 1.0);
+    if (translating)
+    {
+        if (texture->type == plutovg_texture_type_plain)
+            blend_untransformed_argb(pluto->surface, state->op, rle, &data);
+        else
+            blend_untransformed_tiled_argb(pluto->surface, state->op, rle, &data);
+    }
+    else
+    {
+        if (texture->type == plutovg_texture_type_plain)
+            blend_transformed_argb(pluto->surface, state->op, rle, &data);
+        else
+            blend_transformed_tiled_argb(pluto->surface, state->op, rle, &data);
+    }
+}

--- a/source/plutovg/plutovg-dash.cpp
+++ b/source/plutovg/plutovg-dash.cpp
@@ -1,0 +1,115 @@
+#include "plutovg-private.h"
+
+#include <math.h>
+
+plutovg_dash_t* plutovg_dash_create(double offset, const double* data, int size)
+{
+    if (data == nullptr || size == 0)
+        return nullptr;
+
+    plutovg_dash_t* dash = new plutovg_dash_t;
+    dash->offset = offset;
+    dash->data = new double[size];
+    dash->size = size;
+    memcpy(dash->data, data, (size_t) size * sizeof(double));
+    return dash;
+}
+
+plutovg_dash_t* plutovg_dash_clone(const plutovg_dash_t* dash)
+{
+    if (dash == nullptr)
+        return nullptr;
+
+    return plutovg_dash_create(dash->offset, dash->data, dash->size);
+}
+
+void plutovg_dash_destroy(plutovg_dash_t* dash)
+{
+    if (dash == nullptr)
+        return;
+
+    delete[] dash->data;
+    delete dash;
+}
+
+plutovg_path_t* plutovg_dash_path(const plutovg_dash_t* dash, const plutovg_path_t* path)
+{
+    if (dash->data == NULL || dash->size == 0)
+        return plutovg_path_clone(path);
+
+    int toggle = 1;
+    int offset = 0;
+    double phase = dash->offset;
+    while (phase >= dash->data[offset])
+    {
+        toggle = !toggle;
+        phase -= dash->data[offset];
+        offset += 1;
+        if (offset == dash->size)
+            offset = 0;
+    }
+
+    plutovg_path_t* flat = plutovg_path_clone_flat(path);
+    plutovg_path_t* result = plutovg_path_create();
+
+    plutovg_path_element_t* elements = flat->elements.data();
+    plutovg_path_element_t* end = elements + flat->elements.size();
+    plutovg_point_t* points = flat->points.data();
+
+    while (elements < end)
+    {
+        int itoggle = toggle;
+        int ioffset = offset;
+        double iphase = phase;
+
+        double x0 = points->x;
+        double y0 = points->y;
+
+        if (itoggle)
+            plutovg_path_move_to(result, x0, y0);
+
+        ++elements;
+        ++points;
+
+        while (elements < end && *elements == plutovg_path_element_line_to)
+        {
+            double dx = points->x - x0;
+            double dy = points->y - y0;
+            double dist0 = sqrt(dx * dx + dy * dy);
+            double dist1 = 0;
+
+            while (dist0 - dist1 > dash->data[ioffset] - iphase)
+            {
+                dist1 += dash->data[ioffset] - iphase;
+                double a = dist1 / dist0;
+                double x = x0 + a * dx;
+                double y = y0 + a * dy;
+
+                if (itoggle)
+                    plutovg_path_line_to(result, x, y);
+                else
+                    plutovg_path_move_to(result, x, y);
+
+                itoggle = !itoggle;
+                iphase = 0;
+                ioffset += 1;
+                if (ioffset == dash->size)
+                    ioffset = 0;
+            }
+
+            iphase += dist0 - dist1;
+
+            x0 = points->x;
+            y0 = points->y;
+
+            if (itoggle)
+                plutovg_path_line_to(result, x0, y0);
+
+            ++elements;
+            ++points;
+        }
+    }
+
+    plutovg_path_destroy(flat);
+    return result;
+}

--- a/source/plutovg/plutovg-dash.cpp
+++ b/source/plutovg/plutovg-dash.cpp
@@ -1,5 +1,6 @@
 #include "plutovg-private.h"
 
+#include <cstring>
 #include <math.h>
 
 plutovg_dash_t* plutovg_dash_create(double offset, const double* data, int size)

--- a/source/plutovg/plutovg-ft-math.cpp
+++ b/source/plutovg/plutovg-ft-math.cpp
@@ -1,0 +1,446 @@
+/***************************************************************************/
+/*                                                                         */
+/*  fttrigon.c                                                             */
+/*                                                                         */
+/*    FreeType trigonometric functions (body).                             */
+/*                                                                         */
+/*  Copyright 2001-2005, 2012-2013 by                                      */
+/*  David Turner, Robert Wilhelm, and Werner Lemberg.                      */
+/*                                                                         */
+/*  This file is part of the FreeType project, and may only be used,       */
+/*  modified, and distributed under the terms of the FreeType project      */
+/*  license, LICENSE.TXT.  By continuing to use, modify, or distribute     */
+/*  this file you indicate that you have read the license and              */
+/*  understand and accept it fully.                                        */
+/*                                                                         */
+/***************************************************************************/
+
+#include "plutovg-ft-math.h"
+
+#if defined(_MSC_VER)
+#include <intrin.h>
+static unsigned int __inline clz(unsigned int x) {
+    unsigned long r = 0;
+    if (x != 0)
+    {
+        _BitScanReverse(&r, x);
+    }
+    return  r;
+}
+#define PVG_FT_MSB(x)  (clz(x))
+#elif defined(__GNUC__)
+#define PVG_FT_MSB(x)  (31 - __builtin_clz(x))
+#else
+static unsigned int __inline clz(unsigned int x) {
+    int c = 31;
+    x &= ~x + 1;
+    if (n & 0x0000FFFF) c -= 16;
+    if (n & 0x00FF00FF) c -= 8;
+    if (n & 0x0F0F0F0F) c -= 4;
+    if (n & 0x33333333) c -= 2;
+    if (n & 0x55555555) c -= 1;
+    return c;
+}
+#define PVG_FT_MSB(x)  (clz(x))
+#endif
+
+#define PVG_FT_PAD_FLOOR(x, n) ((x) & ~((n)-1))
+#define PVG_FT_PAD_ROUND(x, n) PVG_FT_PAD_FLOOR((x) + ((n) / 2), n)
+#define PVG_FT_PAD_CEIL(x, n) PVG_FT_PAD_FLOOR((x) + ((n)-1), n)
+
+#define PVG_FT_BEGIN_STMNT do {
+#define PVG_FT_END_STMNT } while (0)
+
+/* transfer sign leaving a positive number */
+#define PVG_FT_MOVE_SIGN(x, s) \
+    PVG_FT_BEGIN_STMNT         \
+    if (x < 0) {              \
+        x = -x;               \
+        s = -s;               \
+    }                         \
+    PVG_FT_END_STMNT
+
+PVG_FT_Long PVG_FT_MulFix(PVG_FT_Long a, PVG_FT_Long b)
+{
+    PVG_FT_Int  s = 1;
+    PVG_FT_Long c;
+
+    PVG_FT_MOVE_SIGN(a, s);
+    PVG_FT_MOVE_SIGN(b, s);
+
+    c = (PVG_FT_Long)(((PVG_FT_Int64)a * b + 0x8000L) >> 16);
+
+    return (s > 0) ? c : -c;
+}
+
+PVG_FT_Long PVG_FT_MulDiv(PVG_FT_Long a, PVG_FT_Long b, PVG_FT_Long c)
+{
+    PVG_FT_Int  s = 1;
+    PVG_FT_Long d;
+
+    PVG_FT_MOVE_SIGN(a, s);
+    PVG_FT_MOVE_SIGN(b, s);
+    PVG_FT_MOVE_SIGN(c, s);
+
+    d = (PVG_FT_Long)(c > 0 ? ((PVG_FT_Int64)a * b + (c >> 1)) / c : 0x7FFFFFFFL);
+
+    return (s > 0) ? d : -d;
+}
+
+PVG_FT_Long PVG_FT_DivFix(PVG_FT_Long a, PVG_FT_Long b)
+{
+    PVG_FT_Int  s = 1;
+    PVG_FT_Long q;
+
+    PVG_FT_MOVE_SIGN(a, s);
+    PVG_FT_MOVE_SIGN(b, s);
+
+    q = (PVG_FT_Long)(b > 0 ? (((PVG_FT_UInt64)a << 16) + (b >> 1)) / b
+                           : 0x7FFFFFFFL);
+
+    return (s < 0 ? -q : q);
+}
+
+/*************************************************************************/
+/*                                                                       */
+/* This is a fixed-point CORDIC implementation of trigonometric          */
+/* functions as well as transformations between Cartesian and polar      */
+/* coordinates.  The angles are represented as 16.16 fixed-point values  */
+/* in degrees, i.e., the angular resolution is 2^-16 degrees.  Note that */
+/* only vectors longer than 2^16*180/pi (or at least 22 bits) on a       */
+/* discrete Cartesian grid can have the same or better angular           */
+/* resolution.  Therefore, to maintain this precision, some functions    */
+/* require an interim upscaling of the vectors, whereas others operate   */
+/* with 24-bit long vectors directly.                                    */
+/*                                                                       */
+/*************************************************************************/
+
+/* the Cordic shrink factor 0.858785336480436 * 2^32 */
+#define PVG_FT_TRIG_SCALE 0xDBD95B16UL
+
+/* the highest bit in overflow-safe vector components, */
+/* MSB of 0.858785336480436 * sqrt(0.5) * 2^30         */
+#define PVG_FT_TRIG_SAFE_MSB 29
+
+/* this table was generated for PVG_FT_PI = 180L << 16, i.e. degrees */
+#define PVG_FT_TRIG_MAX_ITERS 23
+
+static const PVG_FT_Fixed ft_trig_arctan_table[] = {
+    1740967L, 919879L, 466945L, 234379L, 117304L, 58666L, 29335L, 14668L,
+    7334L,    3667L,   1833L,   917L,    458L,    229L,   115L,   57L,
+    29L,      14L,     7L,      4L,      2L,      1L};
+
+/* multiply a given value by the CORDIC shrink factor */
+static PVG_FT_Fixed ft_trig_downscale(PVG_FT_Fixed val)
+{
+    PVG_FT_Fixed s;
+    PVG_FT_Int64 v;
+
+    s = val;
+    val = PVG_FT_ABS(val);
+
+    v = (val * (PVG_FT_Int64)PVG_FT_TRIG_SCALE) + 0x100000000UL;
+    val = (PVG_FT_Fixed)(v >> 32);
+
+    return (s >= 0) ? val : -val;
+}
+
+/* undefined and never called for zero vector */
+static PVG_FT_Int ft_trig_prenorm(PVG_FT_Vector* vec)
+{
+    PVG_FT_Pos x, y;
+    PVG_FT_Int shift;
+
+    x = vec->x;
+    y = vec->y;
+
+    shift = PVG_FT_MSB(PVG_FT_ABS(x) | PVG_FT_ABS(y));
+
+    if (shift <= PVG_FT_TRIG_SAFE_MSB) {
+        shift = PVG_FT_TRIG_SAFE_MSB - shift;
+        vec->x = (PVG_FT_Pos)((PVG_FT_ULong)x << shift);
+        vec->y = (PVG_FT_Pos)((PVG_FT_ULong)y << shift);
+    } else {
+        shift -= PVG_FT_TRIG_SAFE_MSB;
+        vec->x = x >> shift;
+        vec->y = y >> shift;
+        shift = -shift;
+    }
+
+    return shift;
+}
+
+static void ft_trig_pseudo_rotate(PVG_FT_Vector* vec, PVG_FT_Angle theta)
+{
+    PVG_FT_Int          i;
+    PVG_FT_Fixed        x, y, xtemp, b;
+    const PVG_FT_Fixed* arctanptr;
+
+    x = vec->x;
+    y = vec->y;
+
+    /* Rotate inside [-PI/4,PI/4] sector */
+    while (theta < -PVG_FT_ANGLE_PI4) {
+        xtemp = y;
+        y = -x;
+        x = xtemp;
+        theta += PVG_FT_ANGLE_PI2;
+    }
+
+    while (theta > PVG_FT_ANGLE_PI4) {
+        xtemp = -y;
+        y = x;
+        x = xtemp;
+        theta -= PVG_FT_ANGLE_PI2;
+    }
+
+    arctanptr = ft_trig_arctan_table;
+
+    /* Pseudorotations, with right shifts */
+    for (i = 1, b = 1; i < PVG_FT_TRIG_MAX_ITERS; b <<= 1, i++) {
+        PVG_FT_Fixed v1 = ((y + b) >> i);
+        PVG_FT_Fixed v2 = ((x + b) >> i);
+        if (theta < 0) {
+            xtemp = x + v1;
+            y = y - v2;
+            x = xtemp;
+            theta += *arctanptr++;
+        } else {
+            xtemp = x - v1;
+            y = y + v2;
+            x = xtemp;
+            theta -= *arctanptr++;
+        }
+    }
+
+    vec->x = x;
+    vec->y = y;
+}
+
+static void ft_trig_pseudo_polarize(PVG_FT_Vector* vec)
+{
+    PVG_FT_Angle        theta;
+    PVG_FT_Int          i;
+    PVG_FT_Fixed        x, y, xtemp, b;
+    const PVG_FT_Fixed* arctanptr;
+
+    x = vec->x;
+    y = vec->y;
+
+    /* Get the vector into [-PI/4,PI/4] sector */
+    if (y > x) {
+        if (y > -x) {
+            theta = PVG_FT_ANGLE_PI2;
+            xtemp = y;
+            y = -x;
+            x = xtemp;
+        } else {
+            theta = y > 0 ? PVG_FT_ANGLE_PI : -PVG_FT_ANGLE_PI;
+            x = -x;
+            y = -y;
+        }
+    } else {
+        if (y < -x) {
+            theta = -PVG_FT_ANGLE_PI2;
+            xtemp = -y;
+            y = x;
+            x = xtemp;
+        } else {
+            theta = 0;
+        }
+    }
+
+    arctanptr = ft_trig_arctan_table;
+
+    /* Pseudorotations, with right shifts */
+    for (i = 1, b = 1; i < PVG_FT_TRIG_MAX_ITERS; b <<= 1, i++) {
+        PVG_FT_Fixed v1 = ((y + b) >> i);
+        PVG_FT_Fixed v2 = ((x + b) >> i);
+        if (y > 0) {
+            xtemp = x + v1;
+            y = y - v2;
+            x = xtemp;
+            theta += *arctanptr++;
+        } else {
+            xtemp = x - v1;
+            y = y + v2;
+            x = xtemp;
+            theta -= *arctanptr++;
+        }
+    }
+
+    /* round theta */
+    if (theta >= 0)
+        theta = PVG_FT_PAD_ROUND(theta, 32);
+    else
+        theta = -PVG_FT_PAD_ROUND(-theta, 32);
+
+    vec->x = x;
+    vec->y = theta;
+}
+
+/* documentation is in fttrigon.h */
+
+PVG_FT_Fixed PVG_FT_Cos(PVG_FT_Angle angle)
+{
+    PVG_FT_Vector v;
+
+    v.x = PVG_FT_TRIG_SCALE >> 8;
+    v.y = 0;
+    ft_trig_pseudo_rotate(&v, angle);
+
+    return (v.x + 0x80L) >> 8;
+}
+
+/* documentation is in fttrigon.h */
+
+PVG_FT_Fixed PVG_FT_Sin(PVG_FT_Angle angle)
+{
+    return PVG_FT_Cos(PVG_FT_ANGLE_PI2 - angle);
+}
+
+/* documentation is in fttrigon.h */
+
+PVG_FT_Fixed PVG_FT_Tan(PVG_FT_Angle angle)
+{
+    PVG_FT_Vector v;
+
+    v.x = PVG_FT_TRIG_SCALE >> 8;
+    v.y = 0;
+    ft_trig_pseudo_rotate(&v, angle);
+
+    return PVG_FT_DivFix(v.y, v.x);
+}
+
+/* documentation is in fttrigon.h */
+
+PVG_FT_Angle PVG_FT_Atan2(PVG_FT_Fixed dx, PVG_FT_Fixed dy)
+{
+    PVG_FT_Vector v;
+
+    if (dx == 0 && dy == 0) return 0;
+
+    v.x = dx;
+    v.y = dy;
+    ft_trig_prenorm(&v);
+    ft_trig_pseudo_polarize(&v);
+
+    return v.y;
+}
+
+/* documentation is in fttrigon.h */
+
+void PVG_FT_Vector_Unit(PVG_FT_Vector* vec, PVG_FT_Angle angle)
+{
+    vec->x = PVG_FT_TRIG_SCALE >> 8;
+    vec->y = 0;
+    ft_trig_pseudo_rotate(vec, angle);
+    vec->x = (vec->x + 0x80L) >> 8;
+    vec->y = (vec->y + 0x80L) >> 8;
+}
+
+void PVG_FT_Vector_Rotate(PVG_FT_Vector* vec, PVG_FT_Angle angle)
+{
+    PVG_FT_Int     shift;
+    PVG_FT_Vector  v = *vec;
+
+    if ( v.x == 0 && v.y == 0 )
+        return;
+
+    shift = ft_trig_prenorm( &v );
+    ft_trig_pseudo_rotate( &v, angle );
+    v.x = ft_trig_downscale( v.x );
+    v.y = ft_trig_downscale( v.y );
+
+    if ( shift > 0 )
+    {
+        PVG_FT_Int32  half = (PVG_FT_Int32)1L << ( shift - 1 );
+
+
+        vec->x = ( v.x + half - ( v.x < 0 ) ) >> shift;
+        vec->y = ( v.y + half - ( v.y < 0 ) ) >> shift;
+    }
+    else
+    {
+        shift  = -shift;
+        vec->x = (PVG_FT_Pos)( (PVG_FT_ULong)v.x << shift );
+        vec->y = (PVG_FT_Pos)( (PVG_FT_ULong)v.y << shift );
+    }
+}
+
+/* documentation is in fttrigon.h */
+
+PVG_FT_Fixed PVG_FT_Vector_Length(PVG_FT_Vector* vec)
+{
+    PVG_FT_Int    shift;
+    PVG_FT_Vector v;
+
+    v = *vec;
+
+    /* handle trivial cases */
+    if (v.x == 0) {
+        return PVG_FT_ABS(v.y);
+    } else if (v.y == 0) {
+        return PVG_FT_ABS(v.x);
+    }
+
+    /* general case */
+    shift = ft_trig_prenorm(&v);
+    ft_trig_pseudo_polarize(&v);
+
+    v.x = ft_trig_downscale(v.x);
+
+    if (shift > 0) return (v.x + (1 << (shift - 1))) >> shift;
+
+    return (PVG_FT_Fixed)((PVG_FT_UInt32)v.x << -shift);
+}
+
+/* documentation is in fttrigon.h */
+
+void PVG_FT_Vector_Polarize(PVG_FT_Vector* vec, PVG_FT_Fixed* length,
+    PVG_FT_Angle* angle)
+{
+    PVG_FT_Int    shift;
+    PVG_FT_Vector v;
+
+    v = *vec;
+
+    if (v.x == 0 && v.y == 0) return;
+
+    shift = ft_trig_prenorm(&v);
+    ft_trig_pseudo_polarize(&v);
+
+    v.x = ft_trig_downscale(v.x);
+
+    *length = (shift >= 0) ? (v.x >> shift)
+                           : (PVG_FT_Fixed)((PVG_FT_UInt32)v.x << -shift);
+    *angle = v.y;
+}
+
+/* documentation is in fttrigon.h */
+
+void PVG_FT_Vector_From_Polar(PVG_FT_Vector* vec, PVG_FT_Fixed length,
+    PVG_FT_Angle angle)
+{
+    vec->x = length;
+    vec->y = 0;
+
+    PVG_FT_Vector_Rotate(vec, angle);
+}
+
+/* documentation is in fttrigon.h */
+
+PVG_FT_Angle PVG_FT_Angle_Diff( PVG_FT_Angle  angle1, PVG_FT_Angle  angle2 )
+{
+    PVG_FT_Angle  delta = angle2 - angle1;
+
+    while ( delta <= -PVG_FT_ANGLE_PI )
+        delta += PVG_FT_ANGLE_2PI;
+
+    while ( delta > PVG_FT_ANGLE_PI )
+        delta -= PVG_FT_ANGLE_2PI;
+
+    return delta;
+}
+
+/* END */

--- a/source/plutovg/plutovg-ft-math.h
+++ b/source/plutovg/plutovg-ft-math.h
@@ -1,0 +1,436 @@
+/***************************************************************************/
+/*                                                                         */
+/*  fttrigon.h                                                             */
+/*                                                                         */
+/*    FreeType trigonometric functions (specification).                    */
+/*                                                                         */
+/*  Copyright 2001, 2003, 2005, 2007, 2013 by                              */
+/*  David Turner, Robert Wilhelm, and Werner Lemberg.                      */
+/*                                                                         */
+/*  This file is part of the FreeType project, and may only be used,       */
+/*  modified, and distributed under the terms of the FreeType project      */
+/*  license, LICENSE.TXT.  By continuing to use, modify, or distribute     */
+/*  this file you indicate that you have read the license and              */
+/*  understand and accept it fully.                                        */
+/*                                                                         */
+/***************************************************************************/
+
+#ifndef PLUTOVG_FT_MATH_H
+#define PLUTOVG_FT_MATH_H
+
+#include "plutovg-ft-types.h"
+
+/*************************************************************************/
+/*                                                                       */
+/* The min and max functions missing in C.  As usual, be careful not to  */
+/* write things like PVG_FT_MIN( a++, b++ ) to avoid side effects.           */
+/*                                                                       */
+#define PVG_FT_MIN( a, b )  ( (a) < (b) ? (a) : (b) )
+#define PVG_FT_MAX( a, b )  ( (a) > (b) ? (a) : (b) )
+
+#define PVG_FT_ABS( a )     ( (a) < 0 ? -(a) : (a) )
+
+/*
+ * Approximate sqrt(x*x+y*y) using the `alpha max plus beta min'
+ * algorithm.  We use alpha = 1, beta = 3/8, giving us results with a
+ * largest error less than 7% compared to the exact value.
+ */
+#define PVG_FT_HYPOT( x, y )                 \
+          ( x = PVG_FT_ABS( x ),             \
+            y = PVG_FT_ABS( y ),             \
+            x > y ? x + ( 3 * y >> 3 )   \
+                  : y + ( 3 * x >> 3 ) )
+
+/*************************************************************************/
+/*                                                                       */
+/* <Function>                                                            */
+/*    PVG_FT_MulFix                                                      */
+/*                                                                       */
+/* <Description>                                                         */
+/*    A very simple function used to perform the computation             */
+/*    `(a*b)/0x10000' with maximum accuracy.  Most of the time this is   */
+/*    used to multiply a given value by a 16.16 fixed-point factor.      */
+/*                                                                       */
+/* <Input>                                                               */
+/*    a :: The first multiplier.                                         */
+/*    b :: The second multiplier.  Use a 16.16 factor here whenever      */
+/*         possible (see note below).                                    */
+/*                                                                       */
+/* <Return>                                                              */
+/*    The result of `(a*b)/0x10000'.                                     */
+/*                                                                       */
+/* <Note>                                                                */
+/*    This function has been optimized for the case where the absolute   */
+/*    value of `a' is less than 2048, and `b' is a 16.16 scaling factor. */
+/*    As this happens mainly when scaling from notional units to         */
+/*    fractional pixels in FreeType, it resulted in noticeable speed     */
+/*    improvements between versions 2.x and 1.x.                         */
+/*                                                                       */
+/*    As a conclusion, always try to place a 16.16 factor as the         */
+/*    _second_ argument of this function; this can make a great          */
+/*    difference.                                                        */
+/*                                                                       */
+PVG_FT_Long
+PVG_FT_MulFix( PVG_FT_Long  a,
+    PVG_FT_Long  b );
+
+/*************************************************************************/
+/*                                                                       */
+/* <Function>                                                            */
+/*    PVG_FT_MulDiv                                                      */
+/*                                                                       */
+/* <Description>                                                         */
+/*    A very simple function used to perform the computation `(a*b)/c'   */
+/*    with maximum accuracy (it uses a 64-bit intermediate integer       */
+/*    whenever necessary).                                               */
+/*                                                                       */
+/*    This function isn't necessarily as fast as some processor specific */
+/*    operations, but is at least completely portable.                   */
+/*                                                                       */
+/* <Input>                                                               */
+/*    a :: The first multiplier.                                         */
+/*    b :: The second multiplier.                                        */
+/*    c :: The divisor.                                                  */
+/*                                                                       */
+/* <Return>                                                              */
+/*    The result of `(a*b)/c'.  This function never traps when trying to */
+/*    divide by zero; it simply returns `MaxInt' or `MinInt' depending   */
+/*    on the signs of `a' and `b'.                                       */
+/*                                                                       */
+PVG_FT_Long
+PVG_FT_MulDiv( PVG_FT_Long  a,
+    PVG_FT_Long  b,
+    PVG_FT_Long  c );
+
+/*************************************************************************/
+/*                                                                       */
+/* <Function>                                                            */
+/*    PVG_FT_DivFix                                                      */
+/*                                                                       */
+/* <Description>                                                         */
+/*    A very simple function used to perform the computation             */
+/*    `(a*0x10000)/b' with maximum accuracy.  Most of the time, this is  */
+/*    used to divide a given value by a 16.16 fixed-point factor.        */
+/*                                                                       */
+/* <Input>                                                               */
+/*    a :: The numerator.                                                */
+/*    b :: The denominator.  Use a 16.16 factor here.                    */
+/*                                                                       */
+/* <Return>                                                              */
+/*    The result of `(a*0x10000)/b'.                                     */
+/*                                                                       */
+PVG_FT_Long
+PVG_FT_DivFix( PVG_FT_Long  a,
+    PVG_FT_Long  b );
+
+
+
+/*************************************************************************/
+/*                                                                       */
+/* <Section>                                                             */
+/*   computations                                                        */
+/*                                                                       */
+/*************************************************************************/
+
+
+/*************************************************************************
+ *
+ * @type:
+ *   PVG_FT_Angle
+ *
+ * @description:
+ *   This type is used to model angle values in FreeType.  Note that the
+ *   angle is a 16.16 fixed-point value expressed in degrees.
+ *
+ */
+typedef PVG_FT_Fixed  PVG_FT_Angle;
+
+
+/*************************************************************************
+ *
+ * @macro:
+ *   PVG_FT_ANGLE_PI
+ *
+ * @description:
+ *   The angle pi expressed in @PVG_FT_Angle units.
+ *
+ */
+#define PVG_FT_ANGLE_PI  ( 180L << 16 )
+
+
+/*************************************************************************
+ *
+ * @macro:
+ *   PVG_FT_ANGLE_2PI
+ *
+ * @description:
+ *   The angle 2*pi expressed in @PVG_FT_Angle units.
+ *
+ */
+#define PVG_FT_ANGLE_2PI  ( PVG_FT_ANGLE_PI * 2 )
+
+
+/*************************************************************************
+ *
+ * @macro:
+ *   PVG_FT_ANGLE_PI2
+ *
+ * @description:
+ *   The angle pi/2 expressed in @PVG_FT_Angle units.
+ *
+ */
+#define PVG_FT_ANGLE_PI2  ( PVG_FT_ANGLE_PI / 2 )
+
+
+/*************************************************************************
+ *
+ * @macro:
+ *   PVG_FT_ANGLE_PI4
+ *
+ * @description:
+ *   The angle pi/4 expressed in @PVG_FT_Angle units.
+ *
+ */
+#define PVG_FT_ANGLE_PI4  ( PVG_FT_ANGLE_PI / 4 )
+
+
+/*************************************************************************
+ *
+ * @function:
+ *   PVG_FT_Sin
+ *
+ * @description:
+ *   Return the sinus of a given angle in fixed-point format.
+ *
+ * @input:
+ *   angle ::
+ *     The input angle.
+ *
+ * @return:
+ *   The sinus value.
+ *
+ * @note:
+ *   If you need both the sinus and cosinus for a given angle, use the
+ *   function @PVG_FT_Vector_Unit.
+ *
+ */
+PVG_FT_Fixed
+PVG_FT_Sin( PVG_FT_Angle  angle );
+
+
+/*************************************************************************
+ *
+ * @function:
+ *   PVG_FT_Cos
+ *
+ * @description:
+ *   Return the cosinus of a given angle in fixed-point format.
+ *
+ * @input:
+ *   angle ::
+ *     The input angle.
+ *
+ * @return:
+ *   The cosinus value.
+ *
+ * @note:
+ *   If you need both the sinus and cosinus for a given angle, use the
+ *   function @PVG_FT_Vector_Unit.
+ *
+ */
+PVG_FT_Fixed
+PVG_FT_Cos( PVG_FT_Angle  angle );
+
+
+/*************************************************************************
+ *
+ * @function:
+ *   PVG_FT_Tan
+ *
+ * @description:
+ *   Return the tangent of a given angle in fixed-point format.
+ *
+ * @input:
+ *   angle ::
+ *     The input angle.
+ *
+ * @return:
+ *   The tangent value.
+ *
+ */
+PVG_FT_Fixed
+PVG_FT_Tan( PVG_FT_Angle  angle );
+
+
+/*************************************************************************
+ *
+ * @function:
+ *   PVG_FT_Atan2
+ *
+ * @description:
+ *   Return the arc-tangent corresponding to a given vector (x,y) in
+ *   the 2d plane.
+ *
+ * @input:
+ *   x ::
+ *     The horizontal vector coordinate.
+ *
+ *   y ::
+ *     The vertical vector coordinate.
+ *
+ * @return:
+ *   The arc-tangent value (i.e. angle).
+ *
+ */
+PVG_FT_Angle
+PVG_FT_Atan2( PVG_FT_Fixed  x,
+    PVG_FT_Fixed  y );
+
+
+/*************************************************************************
+ *
+ * @function:
+ *   PVG_FT_Angle_Diff
+ *
+ * @description:
+ *   Return the difference between two angles.  The result is always
+ *   constrained to the ]-PI..PI] interval.
+ *
+ * @input:
+ *   angle1 ::
+ *     First angle.
+ *
+ *   angle2 ::
+ *     Second angle.
+ *
+ * @return:
+ *   Constrained value of `value2-value1'.
+ *
+ */
+PVG_FT_Angle
+PVG_FT_Angle_Diff( PVG_FT_Angle  angle1,
+    PVG_FT_Angle  angle2 );
+
+
+/*************************************************************************
+ *
+ * @function:
+ *   PVG_FT_Vector_Unit
+ *
+ * @description:
+ *   Return the unit vector corresponding to a given angle.  After the
+ *   call, the value of `vec.x' will be `sin(angle)', and the value of
+ *   `vec.y' will be `cos(angle)'.
+ *
+ *   This function is useful to retrieve both the sinus and cosinus of a
+ *   given angle quickly.
+ *
+ * @output:
+ *   vec ::
+ *     The address of target vector.
+ *
+ * @input:
+ *   angle ::
+ *     The input angle.
+ *
+ */
+void
+PVG_FT_Vector_Unit( PVG_FT_Vector*  vec,
+    PVG_FT_Angle    angle );
+
+
+/*************************************************************************
+ *
+ * @function:
+ *   PVG_FT_Vector_Rotate
+ *
+ * @description:
+ *   Rotate a vector by a given angle.
+ *
+ * @inout:
+ *   vec ::
+ *     The address of target vector.
+ *
+ * @input:
+ *   angle ::
+ *     The input angle.
+ *
+ */
+void
+PVG_FT_Vector_Rotate( PVG_FT_Vector*  vec,
+    PVG_FT_Angle    angle );
+
+
+/*************************************************************************
+ *
+ * @function:
+ *   PVG_FT_Vector_Length
+ *
+ * @description:
+ *   Return the length of a given vector.
+ *
+ * @input:
+ *   vec ::
+ *     The address of target vector.
+ *
+ * @return:
+ *   The vector length, expressed in the same units that the original
+ *   vector coordinates.
+ *
+ */
+PVG_FT_Fixed
+PVG_FT_Vector_Length( PVG_FT_Vector*  vec );
+
+
+/*************************************************************************
+ *
+ * @function:
+ *   PVG_FT_Vector_Polarize
+ *
+ * @description:
+ *   Compute both the length and angle of a given vector.
+ *
+ * @input:
+ *   vec ::
+ *     The address of source vector.
+ *
+ * @output:
+ *   length ::
+ *     The vector length.
+ *
+ *   angle ::
+ *     The vector angle.
+ *
+ */
+void
+PVG_FT_Vector_Polarize( PVG_FT_Vector*  vec,
+    PVG_FT_Fixed   *length,
+    PVG_FT_Angle   *angle );
+
+
+/*************************************************************************
+ *
+ * @function:
+ *   PVG_FT_Vector_From_Polar
+ *
+ * @description:
+ *   Compute vector coordinates from a length and angle.
+ *
+ * @output:
+ *   vec ::
+ *     The address of source vector.
+ *
+ * @input:
+ *   length ::
+ *     The vector length.
+ *
+ *   angle ::
+ *     The vector angle.
+ *
+ */
+void
+PVG_FT_Vector_From_Polar( PVG_FT_Vector*  vec,
+    PVG_FT_Fixed    length,
+    PVG_FT_Angle    angle );
+
+#endif /* PLUTOVG_FT_MATH_H */

--- a/source/plutovg/plutovg-ft-raster.cpp
+++ b/source/plutovg/plutovg-ft-raster.cpp
@@ -1,0 +1,1538 @@
+/***************************************************************************/
+/*                                                                         */
+/*  ftgrays.c                                                              */
+/*                                                                         */
+/*    A new `perfect' anti-aliasing renderer (body).                       */
+/*                                                                         */
+/*  Copyright 2000-2003, 2005-2014 by                                      */
+/*  David Turner, Robert Wilhelm, and Werner Lemberg.                      */
+/*                                                                         */
+/*  This file is part of the FreeType project, and may only be used,       */
+/*  modified, and distributed under the terms of the FreeType project      */
+/*  license, LICENSE.TXT.  By continuing to use, modify, or distribute     */
+/*  this file you indicate that you have read the license and              */
+/*  understand and accept it fully.                                        */
+/*                                                                         */
+/***************************************************************************/
+
+/*************************************************************************/
+/*                                                                       */
+/* This is a new anti-aliasing scan-converter for FreeType 2.  The       */
+/* algorithm used here is _very_ different from the one in the standard  */
+/* `ftraster' module.  Actually, `ftgrays' computes the _exact_          */
+/* coverage of the outline on each pixel cell.                           */
+/*                                                                       */
+/* It is based on ideas that I initially found in Raph Levien's          */
+/* excellent LibArt graphics library (see http://www.levien.com/libart   */
+/* for more information, though the web pages do not tell anything       */
+/* about the renderer; you'll have to dive into the source code to       */
+/* understand how it works).                                             */
+/*                                                                       */
+/* Note, however, that this is a _very_ different implementation         */
+/* compared to Raph's.  Coverage information is stored in a very         */
+/* different way, and I don't use sorted vector paths.  Also, it doesn't */
+/* use floating point values.                                            */
+/*                                                                       */
+/* This renderer has the following advantages:                           */
+/*                                                                       */
+/* - It doesn't need an intermediate bitmap.  Instead, one can supply a  */
+/*   callback function that will be called by the renderer to draw gray  */
+/*   spans on any target surface.  You can thus do direct composition on */
+/*   any kind of bitmap, provided that you give the renderer the right   */
+/*   callback.                                                           */
+/*                                                                       */
+/* - A perfect anti-aliaser, i.e., it computes the _exact_ coverage on   */
+/*   each pixel cell.                                                    */
+/*                                                                       */
+/* - It performs a single pass on the outline (the `standard' FT2        */
+/*   renderer makes two passes).                                         */
+/*                                                                       */
+/* - It can easily be modified to render to _any_ number of gray levels  */
+/*   cheaply.                                                            */
+/*                                                                       */
+/* - For small (< 20) pixel sizes, it is faster than the standard        */
+/*   renderer.                                                           */
+/*                                                                       */
+/*************************************************************************/
+
+#include "plutovg-ft-raster.h"
+#include "plutovg-ft-math.h"
+
+#define PVG_FT_BEGIN_STMNT \
+    do                     \
+    {
+#define PVG_FT_END_STMNT \
+    }                    \
+    while (0)
+
+#include <setjmp.h>
+
+#define pvg_ft_setjmp  setjmp
+#define pvg_ft_longjmp longjmp
+#define pvg_ft_jmp_buf jmp_buf
+
+#include <stddef.h>
+
+typedef ptrdiff_t PVG_FT_PtrDist;
+
+#define ErrRaster_Invalid_Mode     -2
+#define ErrRaster_Invalid_Outline  -1
+#define ErrRaster_Invalid_Argument -3
+#define ErrRaster_Memory_Overflow  -4
+#define ErrRaster_OutOfMemory      -6
+
+#include <limits.h>
+#include <stdlib.h>
+
+#define PVG_FT_MINIMUM_POOL_SIZE 8192
+
+#define RAS_ARG  PWorker worker
+#define RAS_ARG_ PWorker worker,
+
+#define RAS_VAR  worker
+#define RAS_VAR_ worker,
+
+#define ras (*worker)
+
+/* must be at least 6 bits! */
+#define PIXEL_BITS 8
+
+#define ONE_PIXEL (1L << PIXEL_BITS)
+#define TRUNC(x)  (TCoord)((x) >> PIXEL_BITS)
+#define FRACT(x)  (TCoord)((x) & (ONE_PIXEL - 1))
+
+#if PIXEL_BITS >= 6
+    #define UPSCALE(x)   ((x) * (ONE_PIXEL >> 6))
+    #define DOWNSCALE(x) ((x) >> (PIXEL_BITS - 6))
+#else
+    #define UPSCALE(x)   ((x) >> (6 - PIXEL_BITS))
+    #define DOWNSCALE(x) ((x) * (64 >> PIXEL_BITS))
+#endif
+
+/* Compute `dividend / divisor' and return both its quotient and     */
+/* remainder, cast to a specific type.  This macro also ensures that */
+/* the remainder is always positive.                                 */
+#define PVG_FT_DIV_MOD(type, dividend, divisor, quotient, remainder) \
+    PVG_FT_BEGIN_STMNT(quotient) = (type) ((dividend) / (divisor));  \
+    (remainder) = (type) ((dividend) % (divisor));                   \
+    if ((remainder) < 0)                                             \
+    {                                                                \
+        (quotient)--;                                                \
+        (remainder) += (type) (divisor);                             \
+    }                                                                \
+    PVG_FT_END_STMNT
+
+/* These macros speed up repetitive divisions by replacing them */
+/* with multiplications and right shifts.                       */
+#define PVG_FT_UDIVPREP(b) long b##_r = (long) (ULONG_MAX >> PIXEL_BITS) / (b)
+#define PVG_FT_UDIV(a, b)  (((unsigned long) (a) * (unsigned long) (b##_r)) >> (sizeof(long) * CHAR_BIT - PIXEL_BITS))
+
+/*************************************************************************/
+/*                                                                       */
+/*   TYPE DEFINITIONS                                                    */
+/*                                                                       */
+
+/* don't change the following types to PVG_FT_Int or PVG_FT_Pos, since we might */
+/* need to define them to "float" or "double" when experimenting with   */
+/* new algorithms                                                       */
+
+typedef long TCoord; /* integer scanline/pixel coordinate */
+typedef long TPos;   /* sub-pixel coordinate              */
+typedef long TArea;  /* cell areas, coordinate products   */
+
+/* maximal number of gray spans in a call to the span callback */
+#define PVG_FT_MAX_GRAY_SPANS 256
+
+typedef struct TCell_* PCell;
+
+typedef struct TCell_
+{
+    int x;
+    int cover;
+    TArea area;
+    PCell next;
+
+} TCell;
+
+typedef struct TWorker_
+{
+    TCoord ex, ey;
+    TPos min_ex, max_ex;
+    TPos min_ey, max_ey;
+    TPos count_ex, count_ey;
+
+    TArea area;
+    int cover;
+    int invalid;
+
+    PCell cells;
+    PVG_FT_PtrDist max_cells;
+    PVG_FT_PtrDist num_cells;
+
+    TPos x, y;
+
+    PVG_FT_Outline outline;
+    PVG_FT_BBox clip_box;
+
+    PVG_FT_Span gray_spans[PVG_FT_MAX_GRAY_SPANS];
+    int num_gray_spans;
+    int skip_spans;
+
+    PVG_FT_Raster_Span_Func render_span;
+    void* render_span_data;
+
+    int band_size;
+    int band_shoot;
+
+    pvg_ft_jmp_buf jump_buffer;
+
+    void* buffer;
+    long buffer_size;
+
+    PCell* ycells;
+    TPos ycount;
+} TWorker, *PWorker;
+
+/*************************************************************************/
+/*                                                                       */
+/* Initialize the cells table.                                           */
+/*                                                                       */
+static void gray_init_cells(RAS_ARG_ void* buffer, long byte_size)
+{
+    ras.buffer = buffer;
+    ras.buffer_size = byte_size;
+
+    ras.ycells = (PCell*) buffer;
+    ras.cells = NULL;
+    ras.max_cells = 0;
+    ras.num_cells = 0;
+    ras.area = 0;
+    ras.cover = 0;
+    ras.invalid = 1;
+}
+
+/*************************************************************************/
+/*                                                                       */
+/* Compute the outline bounding box.                                     */
+/*                                                                       */
+static void gray_compute_cbox(RAS_ARG)
+{
+    PVG_FT_Outline* outline = &ras.outline;
+    PVG_FT_Vector* vec = outline->points;
+    PVG_FT_Vector* limit = vec + outline->n_points;
+
+    if (outline->n_points <= 0)
+    {
+        ras.min_ex = ras.max_ex = 0;
+        ras.min_ey = ras.max_ey = 0;
+        return;
+    }
+
+    ras.min_ex = ras.max_ex = vec->x;
+    ras.min_ey = ras.max_ey = vec->y;
+
+    vec++;
+
+    for (; vec < limit; vec++)
+    {
+        TPos x = vec->x;
+        TPos y = vec->y;
+
+        if (x < ras.min_ex)
+            ras.min_ex = x;
+        if (x > ras.max_ex)
+            ras.max_ex = x;
+        if (y < ras.min_ey)
+            ras.min_ey = y;
+        if (y > ras.max_ey)
+            ras.max_ey = y;
+    }
+
+    /* truncate the bounding box to integer pixels */
+    ras.min_ex = ras.min_ex >> 6;
+    ras.min_ey = ras.min_ey >> 6;
+    ras.max_ex = (ras.max_ex + 63) >> 6;
+    ras.max_ey = (ras.max_ey + 63) >> 6;
+}
+
+/*************************************************************************/
+/*                                                                       */
+/* Record the current cell in the table.                                 */
+/*                                                                       */
+static PCell gray_find_cell(RAS_ARG)
+{
+    PCell *pcell, cell;
+    TPos x = ras.ex;
+
+    if (x > ras.count_ex)
+        x = ras.count_ex;
+
+    pcell = &ras.ycells[ras.ey];
+    for (;;)
+    {
+        cell = *pcell;
+        if (cell == NULL || cell->x > x)
+            break;
+
+        if (cell->x == x)
+            goto Exit;
+
+        pcell = &cell->next;
+    }
+
+    if (ras.num_cells >= ras.max_cells)
+        pvg_ft_longjmp(ras.jump_buffer, 1);
+
+    cell = ras.cells + ras.num_cells++;
+    cell->x = x;
+    cell->area = 0;
+    cell->cover = 0;
+
+    cell->next = *pcell;
+    *pcell = cell;
+
+Exit:
+    return cell;
+}
+
+static void gray_record_cell(RAS_ARG)
+{
+    if (ras.area | ras.cover)
+    {
+        PCell cell = gray_find_cell(RAS_VAR);
+
+        cell->area += ras.area;
+        cell->cover += ras.cover;
+    }
+}
+
+/*************************************************************************/
+/*                                                                       */
+/* Set the current cell to a new position.                               */
+/*                                                                       */
+static void gray_set_cell(RAS_ARG_ TCoord ex, TCoord ey)
+{
+    /* Move the cell pointer to a new position.  We set the `invalid'      */
+    /* flag to indicate that the cell isn't part of those we're interested */
+    /* in during the render phase.  This means that:                       */
+    /*                                                                     */
+    /* . the new vertical position must be within min_ey..max_ey-1.        */
+    /* . the new horizontal position must be strictly less than max_ex     */
+    /*                                                                     */
+    /* Note that if a cell is to the left of the clipping region, it is    */
+    /* actually set to the (min_ex-1) horizontal position.                 */
+
+    /* All cells that are on the left of the clipping region go to the */
+    /* min_ex - 1 horizontal position.                                 */
+    ey -= ras.min_ey;
+
+    if (ex > ras.max_ex)
+        ex = ras.max_ex;
+
+    ex -= ras.min_ex;
+    if (ex < 0)
+        ex = -1;
+
+    /* are we moving to a different cell ? */
+    if (ex != ras.ex || ey != ras.ey)
+    {
+        /* record the current one if it is valid */
+        if (!ras.invalid)
+            gray_record_cell(RAS_VAR);
+
+        ras.area = 0;
+        ras.cover = 0;
+        ras.ex = ex;
+        ras.ey = ey;
+    }
+
+    ras.invalid = ((unsigned int) ey >= (unsigned int) ras.count_ey || ex >= ras.count_ex);
+}
+
+/*************************************************************************/
+/*                                                                       */
+/* Start a new contour at a given cell.                                  */
+/*                                                                       */
+static void gray_start_cell(RAS_ARG_ TCoord ex, TCoord ey)
+{
+    if (ex > ras.max_ex)
+        ex = (TCoord) (ras.max_ex);
+
+    if (ex < ras.min_ex)
+        ex = (TCoord) (ras.min_ex - 1);
+
+    ras.area = 0;
+    ras.cover = 0;
+    ras.ex = ex - ras.min_ex;
+    ras.ey = ey - ras.min_ey;
+    ras.invalid = 0;
+
+    gray_set_cell(RAS_VAR_ ex, ey);
+}
+
+// The new render-line implementation is not yet used
+#if 1
+
+/*************************************************************************/
+/*                                                                       */
+/* Render a scanline as one or more cells.                               */
+/*                                                                       */
+static void gray_render_scanline(RAS_ARG_ TCoord ey, TPos x1, TCoord y1, TPos x2, TCoord y2)
+{
+    TCoord ex1, ex2, fx1, fx2, first, dy, delta, mod;
+    TPos p, dx;
+    int incr;
+
+    ex1 = TRUNC(x1);
+    ex2 = TRUNC(x2);
+
+    /* trivial case.  Happens often */
+    if (y1 == y2)
+    {
+        gray_set_cell(RAS_VAR_ ex2, ey);
+        return;
+    }
+
+    fx1 = FRACT(x1);
+    fx2 = FRACT(x2);
+
+    /* everything is located in a single cell.  That is easy! */
+    /*                                                        */
+    if (ex1 == ex2)
+        goto End;
+
+    /* ok, we'll have to render a run of adjacent cells on the same */
+    /* scanline...                                                  */
+    /*                                                              */
+    dx = x2 - x1;
+    dy = y2 - y1;
+
+    if (dx > 0)
+    {
+        p = (ONE_PIXEL - fx1) * dy;
+        first = ONE_PIXEL;
+        incr = 1;
+    }
+    else
+    {
+        p = fx1 * dy;
+        first = 0;
+        incr = -1;
+        dx = -dx;
+    }
+
+    PVG_FT_DIV_MOD(TCoord, p, dx, delta, mod);
+
+    ras.area += (TArea) (fx1 + first) * delta;
+    ras.cover += delta;
+    y1 += delta;
+    ex1 += incr;
+    gray_set_cell(RAS_VAR_ ex1, ey);
+
+    if (ex1 != ex2)
+    {
+        TCoord lift, rem;
+
+        p = ONE_PIXEL * dy;
+        PVG_FT_DIV_MOD(TCoord, p, dx, lift, rem);
+
+        do
+        {
+            delta = lift;
+            mod += rem;
+            if (mod >= (TCoord) dx)
+            {
+                mod -= (TCoord) dx;
+                delta++;
+            }
+
+            ras.area += (TArea) (ONE_PIXEL * delta);
+            ras.cover += delta;
+            y1 += delta;
+            ex1 += incr;
+            gray_set_cell(RAS_VAR_ ex1, ey);
+        } while (ex1 != ex2);
+    }
+    fx1 = ONE_PIXEL - first;
+
+End:
+    dy = y2 - y1;
+
+    ras.area += (TArea) ((fx1 + fx2) * dy);
+    ras.cover += dy;
+}
+
+/*************************************************************************/
+/*                                                                       */
+/* Render a given line as a series of scanlines.                         */
+/*                                                                       */
+static void gray_render_line(RAS_ARG_ TPos to_x, TPos to_y)
+{
+    TCoord ey1, ey2, fy1, fy2, first, delta, mod;
+    TPos p, dx, dy, x, x2;
+    int incr;
+
+    ey1 = TRUNC(ras.y);
+    ey2 = TRUNC(to_y); /* if (ey2 >= ras.max_ey) ey2 = ras.max_ey-1; */
+
+    /* perform vertical clipping */
+    if ((ey1 >= ras.max_ey && ey2 >= ras.max_ey) || (ey1 < ras.min_ey && ey2 < ras.min_ey))
+        goto End;
+
+    fy1 = FRACT(ras.y);
+    fy2 = FRACT(to_y);
+
+    /* everything is on a single scanline */
+    if (ey1 == ey2)
+    {
+        gray_render_scanline(RAS_VAR_ ey1, ras.x, fy1, to_x, fy2);
+        goto End;
+    }
+
+    dx = to_x - ras.x;
+    dy = to_y - ras.y;
+
+    /* vertical line - avoid calling gray_render_scanline */
+    if (dx == 0)
+    {
+        TCoord ex = TRUNC(ras.x);
+        TCoord two_fx = FRACT(ras.x) << 1;
+        TPos area, max_ey1;
+
+        if (dy > 0)
+        {
+            first = ONE_PIXEL;
+        }
+        else
+        {
+            first = 0;
+        }
+
+        delta = first - fy1;
+        ras.area += (TArea) two_fx * delta;
+        ras.cover += delta;
+
+        delta = first + first - ONE_PIXEL;
+        area = (TArea) two_fx * delta;
+        max_ey1 = ras.count_ey + ras.min_ey;
+        if (dy < 0)
+        {
+            if (ey1 > max_ey1)
+            {
+                ey1 = (max_ey1 > ey2) ? max_ey1 : ey2;
+                gray_set_cell(&ras, ex, ey1);
+            }
+            else
+            {
+                ey1--;
+                gray_set_cell(&ras, ex, ey1);
+            }
+            while (ey1 > ey2 && ey1 >= ras.min_ey)
+            {
+                ras.area += area;
+                ras.cover += delta;
+                ey1--;
+
+                gray_set_cell(&ras, ex, ey1);
+            }
+            if (ey1 != ey2)
+            {
+                ey1 = ey2;
+                gray_set_cell(&ras, ex, ey1);
+            }
+        }
+        else
+        {
+            if (ey1 < ras.min_ey)
+            {
+                ey1 = (ras.min_ey < ey2) ? ras.min_ey : ey2;
+                gray_set_cell(&ras, ex, ey1);
+            }
+            else
+            {
+                ey1++;
+                gray_set_cell(&ras, ex, ey1);
+            }
+            while (ey1 < ey2 && ey1 < max_ey1)
+            {
+                ras.area += area;
+                ras.cover += delta;
+                ey1++;
+
+                gray_set_cell(&ras, ex, ey1);
+            }
+            if (ey1 != ey2)
+            {
+                ey1 = ey2;
+                gray_set_cell(&ras, ex, ey1);
+            }
+        }
+
+        delta = (int) (fy2 - ONE_PIXEL + first);
+        ras.area += (TArea) two_fx * delta;
+        ras.cover += delta;
+
+        goto End;
+    }
+
+    /* ok, we have to render several scanlines */
+    if (dy > 0)
+    {
+        p = (ONE_PIXEL - fy1) * dx;
+        first = ONE_PIXEL;
+        incr = 1;
+    }
+    else
+    {
+        p = fy1 * dx;
+        first = 0;
+        incr = -1;
+        dy = -dy;
+    }
+
+    /* the fractional part of x-delta is mod/dy. It is essential to */
+    /* keep track of its accumulation for accurate rendering.       */
+    PVG_FT_DIV_MOD(TCoord, p, dy, delta, mod);
+
+    x = ras.x + delta;
+    gray_render_scanline(RAS_VAR_ ey1, ras.x, fy1, x, (TCoord) first);
+
+    ey1 += incr;
+    gray_set_cell(RAS_VAR_ TRUNC(x), ey1);
+
+    if (ey1 != ey2)
+    {
+        TCoord lift, rem;
+
+        p = ONE_PIXEL * dx;
+        PVG_FT_DIV_MOD(TCoord, p, dy, lift, rem);
+
+        do
+        {
+            delta = lift;
+            mod += rem;
+            if (mod >= (TCoord) dy)
+            {
+                mod -= (TCoord) dy;
+                delta++;
+            }
+
+            x2 = x + delta;
+            gray_render_scanline(RAS_VAR_ ey1, x, ONE_PIXEL - first, x2, first);
+            x = x2;
+
+            ey1 += incr;
+            gray_set_cell(RAS_VAR_ TRUNC(x), ey1);
+        } while (ey1 != ey2);
+    }
+
+    gray_render_scanline(RAS_VAR_ ey1, x, ONE_PIXEL - first, to_x, fy2);
+
+End:
+    ras.x = to_x;
+    ras.y = to_y;
+}
+
+#else
+
+/*************************************************************************/
+/*                                                                       */
+/* Render a straight line across multiple cells in any direction.        */
+/*                                                                       */
+static void gray_render_line(RAS_ARG_ TPos to_x, TPos to_y)
+{
+    TPos dx, dy, fx1, fy1, fx2, fy2;
+    TCoord ex1, ex2, ey1, ey2;
+
+    ex1 = TRUNC(ras.x);
+    ex2 = TRUNC(to_x);
+    ey1 = TRUNC(ras.y);
+    ey2 = TRUNC(to_y);
+
+    /* perform vertical clipping */
+    if ((ey1 >= ras.max_ey && ey2 >= ras.max_ey) || (ey1 < ras.min_ey && ey2 < ras.min_ey))
+        goto End;
+
+    dx = to_x - ras.x;
+    dy = to_y - ras.y;
+
+    fx1 = FRACT(ras.x);
+    fy1 = FRACT(ras.y);
+
+    if (ex1 == ex2 && ey1 == ey2) /* inside one cell */
+        ;
+    else if (dy == 0) /* ex1 != ex2 */ /* any horizontal line */
+    {
+        ex1 = ex2;
+        gray_set_cell(RAS_VAR_ ex1, ey1);
+    }
+    else if (dx == 0)
+    {
+        if (dy > 0) /* vertical line up */
+            do
+            {
+                fy2 = ONE_PIXEL;
+                ras.cover += (fy2 - fy1);
+                ras.area += (fy2 - fy1) * fx1 * 2;
+                fy1 = 0;
+                ey1++;
+                gray_set_cell(RAS_VAR_ ex1, ey1);
+            } while (ey1 != ey2);
+        else /* vertical line down */
+            do
+            {
+                fy2 = 0;
+                ras.cover += (fy2 - fy1);
+                ras.area += (fy2 - fy1) * fx1 * 2;
+                fy1 = ONE_PIXEL;
+                ey1--;
+                gray_set_cell(RAS_VAR_ ex1, ey1);
+            } while (ey1 != ey2);
+    }
+    else /* any other line */
+    {
+        TArea prod = dx * fy1 - dy * fx1;
+        PVG_FT_UDIVPREP(dx);
+        PVG_FT_UDIVPREP(dy);
+
+        /* The fundamental value `prod' determines which side and the  */
+        /* exact coordinate where the line exits current cell.  It is  */
+        /* also easily updated when moving from one cell to the next.  */
+        do
+        {
+            if (prod <= 0 && prod - dx * ONE_PIXEL > 0) /* left */
+            {
+                fx2 = 0;
+                fy2 = (TPos) PVG_FT_UDIV(-prod, -dx);
+                prod -= dy * ONE_PIXEL;
+                ras.cover += (fy2 - fy1);
+                ras.area += (fy2 - fy1) * (fx1 + fx2);
+                fx1 = ONE_PIXEL;
+                fy1 = fy2;
+                ex1--;
+            }
+            else if (prod - dx * ONE_PIXEL <= 0 && prod - dx * ONE_PIXEL + dy * ONE_PIXEL > 0) /* up */
+            {
+                prod -= dx * ONE_PIXEL;
+                fx2 = (TPos) PVG_FT_UDIV(-prod, dy);
+                fy2 = ONE_PIXEL;
+                ras.cover += (fy2 - fy1);
+                ras.area += (fy2 - fy1) * (fx1 + fx2);
+                fx1 = fx2;
+                fy1 = 0;
+                ey1++;
+            }
+            else if (prod - dx * ONE_PIXEL + dy * ONE_PIXEL <= 0 && prod + dy * ONE_PIXEL >= 0) /* right */
+            {
+                prod += dy * ONE_PIXEL;
+                fx2 = ONE_PIXEL;
+                fy2 = (TPos) PVG_FT_UDIV(prod, dx);
+                ras.cover += (fy2 - fy1);
+                ras.area += (fy2 - fy1) * (fx1 + fx2);
+                fx1 = 0;
+                fy1 = fy2;
+                ex1++;
+            }
+            else /* ( prod                  + dy * ONE_PIXEL <  0 &&
+                      prod                                   >  0 )    down */
+            {
+                fx2 = (TPos) PVG_FT_UDIV(prod, -dy);
+                fy2 = 0;
+                prod += dx * ONE_PIXEL;
+                ras.cover += (fy2 - fy1);
+                ras.area += (fy2 - fy1) * (fx1 + fx2);
+                fx1 = fx2;
+                fy1 = ONE_PIXEL;
+                ey1--;
+            }
+
+            gray_set_cell(RAS_VAR_ ex1, ey1);
+        } while (ex1 != ex2 || ey1 != ey2);
+    }
+
+    fx2 = FRACT(to_x);
+    fy2 = FRACT(to_y);
+
+    ras.cover += (fy2 - fy1);
+    ras.area += (fy2 - fy1) * (fx1 + fx2);
+
+End:
+    ras.x = to_x;
+    ras.y = to_y;
+}
+
+#endif
+
+static void gray_split_conic(PVG_FT_Vector* base)
+{
+    TPos a, b;
+
+    base[4].x = base[2].x;
+    b = base[1].x;
+    a = base[3].x = (base[2].x + b) / 2;
+    b = base[1].x = (base[0].x + b) / 2;
+    base[2].x = (a + b) / 2;
+
+    base[4].y = base[2].y;
+    b = base[1].y;
+    a = base[3].y = (base[2].y + b) / 2;
+    b = base[1].y = (base[0].y + b) / 2;
+    base[2].y = (a + b) / 2;
+}
+
+static void gray_render_conic(RAS_ARG_ const PVG_FT_Vector* control, const PVG_FT_Vector* to)
+{
+    PVG_FT_Vector bez_stack[16 * 2 + 1]; /* enough to accommodate bisections */
+    PVG_FT_Vector* arc = bez_stack;
+    TPos dx, dy;
+    int draw, split;
+
+    arc[0].x = UPSCALE(to->x);
+    arc[0].y = UPSCALE(to->y);
+    arc[1].x = UPSCALE(control->x);
+    arc[1].y = UPSCALE(control->y);
+    arc[2].x = ras.x;
+    arc[2].y = ras.y;
+
+    /* short-cut the arc that crosses the current band */
+    if ((TRUNC(arc[0].y) >= ras.max_ey && TRUNC(arc[1].y) >= ras.max_ey && TRUNC(arc[2].y) >= ras.max_ey) ||
+        (TRUNC(arc[0].y) < ras.min_ey && TRUNC(arc[1].y) < ras.min_ey && TRUNC(arc[2].y) < ras.min_ey))
+    {
+        ras.x = arc[0].x;
+        ras.y = arc[0].y;
+        return;
+    }
+
+    dx = PVG_FT_ABS(arc[2].x + arc[0].x - 2 * arc[1].x);
+    dy = PVG_FT_ABS(arc[2].y + arc[0].y - 2 * arc[1].y);
+    if (dx < dy)
+        dx = dy;
+
+    /* We can calculate the number of necessary bisections because  */
+    /* each bisection predictably reduces deviation exactly 4-fold. */
+    /* Even 32-bit deviation would vanish after 16 bisections.      */
+    draw = 1;
+    while (dx > ONE_PIXEL / 4)
+    {
+        dx >>= 2;
+        draw <<= 1;
+    }
+
+    /* We use decrement counter to count the total number of segments */
+    /* to draw starting from 2^level. Before each draw we split as    */
+    /* many times as there are trailing zeros in the counter.         */
+    do
+    {
+        split = 1;
+        while ((draw & split) == 0)
+        {
+            gray_split_conic(arc);
+            arc += 2;
+            split <<= 1;
+        }
+
+        gray_render_line(RAS_VAR_ arc[0].x, arc[0].y);
+        arc -= 2;
+
+    } while (--draw);
+}
+
+static void gray_split_cubic(PVG_FT_Vector* base)
+{
+    TPos a, b, c, d;
+
+    base[6].x = base[3].x;
+    c = base[1].x;
+    d = base[2].x;
+    base[1].x = a = (base[0].x + c) / 2;
+    base[5].x = b = (base[3].x + d) / 2;
+    c = (c + d) / 2;
+    base[2].x = a = (a + c) / 2;
+    base[4].x = b = (b + c) / 2;
+    base[3].x = (a + b) / 2;
+
+    base[6].y = base[3].y;
+    c = base[1].y;
+    d = base[2].y;
+    base[1].y = a = (base[0].y + c) / 2;
+    base[5].y = b = (base[3].y + d) / 2;
+    c = (c + d) / 2;
+    base[2].y = a = (a + c) / 2;
+    base[4].y = b = (b + c) / 2;
+    base[3].y = (a + b) / 2;
+}
+
+static void gray_render_cubic(RAS_ARG_ const PVG_FT_Vector* control1, const PVG_FT_Vector* control2, const PVG_FT_Vector* to)
+{
+    PVG_FT_Vector bez_stack[16 * 3 + 1]; /* enough to accommodate bisections */
+    PVG_FT_Vector* arc = bez_stack;
+    TPos dx, dy, dx_, dy_;
+    TPos dx1, dy1, dx2, dy2;
+    TPos L, s, s_limit;
+
+    arc[0].x = UPSCALE(to->x);
+    arc[0].y = UPSCALE(to->y);
+    arc[1].x = UPSCALE(control2->x);
+    arc[1].y = UPSCALE(control2->y);
+    arc[2].x = UPSCALE(control1->x);
+    arc[2].y = UPSCALE(control1->y);
+    arc[3].x = ras.x;
+    arc[3].y = ras.y;
+
+    /* short-cut the arc that crosses the current band */
+    if ((TRUNC(arc[0].y) >= ras.max_ey && TRUNC(arc[1].y) >= ras.max_ey && TRUNC(arc[2].y) >= ras.max_ey &&
+         TRUNC(arc[3].y) >= ras.max_ey) ||
+        (TRUNC(arc[0].y) < ras.min_ey && TRUNC(arc[1].y) < ras.min_ey && TRUNC(arc[2].y) < ras.min_ey &&
+         TRUNC(arc[3].y) < ras.min_ey))
+    {
+        ras.x = arc[0].x;
+        ras.y = arc[0].y;
+        return;
+    }
+
+    for (;;)
+    {
+        /* Decide whether to split or draw. See `Rapid Termination          */
+        /* Evaluation for Recursive Subdivision of Bezier Curves' by Thomas */
+        /* F. Hain, at                                                      */
+        /* http://www.cis.southalabama.edu/~hain/general/Publications/Bezier/Camera-ready%20CISST02%202.pdf */
+
+        /* dx and dy are x and y components of the P0-P3 chord vector. */
+        dx = dx_ = arc[3].x - arc[0].x;
+        dy = dy_ = arc[3].y - arc[0].y;
+
+        L = PVG_FT_HYPOT(dx_, dy_);
+
+        /* Avoid possible arithmetic overflow below by splitting. */
+        if (L >= (1 << 23))
+            goto Split;
+
+        /* Max deviation may be as much as (s/L) * 3/4 (if Hain's v = 1). */
+        s_limit = L * (TPos) (ONE_PIXEL / 6);
+
+        /* s is L * the perpendicular distance from P1 to the line P0-P3. */
+        dx1 = arc[1].x - arc[0].x;
+        dy1 = arc[1].y - arc[0].y;
+        s = PVG_FT_ABS(dy * dx1 - dx * dy1);
+
+        if (s > s_limit)
+            goto Split;
+
+        /* s is L * the perpendicular distance from P2 to the line P0-P3. */
+        dx2 = arc[2].x - arc[0].x;
+        dy2 = arc[2].y - arc[0].y;
+        s = PVG_FT_ABS(dy * dx2 - dx * dy2);
+
+        if (s > s_limit)
+            goto Split;
+
+        /* Split super curvy segments where the off points are so far
+           from the chord that the angles P0-P1-P3 or P0-P2-P3 become
+           acute as detected by appropriate dot products. */
+        if (dx1 * (dx1 - dx) + dy1 * (dy1 - dy) > 0 || dx2 * (dx2 - dx) + dy2 * (dy2 - dy) > 0)
+            goto Split;
+
+        gray_render_line(RAS_VAR_ arc[0].x, arc[0].y);
+
+        if (arc == bez_stack)
+            return;
+
+        arc -= 3;
+        continue;
+
+    Split:
+        gray_split_cubic(arc);
+        arc += 3;
+    }
+}
+
+static int gray_move_to(const PVG_FT_Vector* to, PWorker worker)
+{
+    TPos x, y;
+
+    /* record current cell, if any */
+    if (!ras.invalid)
+        gray_record_cell(worker);
+
+    /* start to a new position */
+    x = UPSCALE(to->x);
+    y = UPSCALE(to->y);
+
+    gray_start_cell(worker, TRUNC(x), TRUNC(y));
+
+    ras.x = x;
+    ras.y = y;
+    return 0;
+}
+
+static void gray_hline(RAS_ARG_ TCoord x, TCoord y, TPos area, int acount)
+{
+    int coverage;
+
+    /* compute the coverage line's coverage, depending on the    */
+    /* outline fill rule                                         */
+    /*                                                           */
+    /* the coverage percentage is area/(PIXEL_BITS*PIXEL_BITS*2) */
+    /*                                                           */
+    coverage = (int) (area >> (PIXEL_BITS * 2 + 1 - 8));
+    /* use range 0..256 */
+    if (coverage < 0)
+        coverage = -coverage;
+
+    if (ras.outline.flags & PVG_FT_OUTLINE_EVEN_ODD_FILL)
+    {
+        coverage &= 511;
+
+        if (coverage > 256)
+            coverage = 512 - coverage;
+        else if (coverage == 256)
+            coverage = 255;
+    }
+    else
+    {
+        /* normal non-zero winding rule */
+        if (coverage >= 256)
+            coverage = 255;
+    }
+
+    y += (TCoord) ras.min_ey;
+    x += (TCoord) ras.min_ex;
+
+    /* PVG_FT_Span.x is an int, so limit our coordinates appropriately */
+    if (x >= (1 << 23))
+        x = (1 << 23) - 1;
+
+    /* PVG_FT_Span.y is an int, so limit our coordinates appropriately */
+    if (y >= (1 << 23))
+        y = (1 << 23) - 1;
+
+    if (coverage)
+    {
+        PVG_FT_Span* span;
+        int count;
+        int skip;
+
+        /* see whether we can add this span to the current list */
+        count = ras.num_gray_spans;
+        span = ras.gray_spans + count - 1;
+        if (count > 0 && span->y == y && span->x + span->len == x && span->coverage == coverage)
+        {
+            span->len = span->len + acount;
+            return;
+        }
+
+        if (count >= PVG_FT_MAX_GRAY_SPANS)
+        {
+            if (ras.render_span && count > ras.skip_spans)
+            {
+                skip = ras.skip_spans > 0 ? ras.skip_spans : 0;
+                ras.render_span(ras.num_gray_spans - skip, ras.gray_spans + skip, ras.render_span_data);
+            }
+
+            ras.skip_spans -= ras.num_gray_spans;
+            /* ras.render_span( span->y, ras.gray_spans, count ); */
+            ras.num_gray_spans = 0;
+
+            span = ras.gray_spans;
+        }
+        else
+            span++;
+
+        /* add a gray span to the current list */
+        span->x = x;
+        span->len = acount;
+        span->y = y;
+        span->coverage = (unsigned char) coverage;
+
+        ras.num_gray_spans++;
+    }
+}
+
+static void gray_sweep(RAS_ARG)
+{
+    int yindex;
+
+    if (ras.num_cells == 0)
+        return;
+
+    for (yindex = 0; yindex < ras.ycount; yindex++)
+    {
+        PCell cell = ras.ycells[yindex];
+        TCoord cover = 0;
+        TCoord x = 0;
+
+        for (; cell != NULL; cell = cell->next)
+        {
+            TArea area;
+
+            if (cell->x > x && cover != 0)
+                gray_hline(RAS_VAR_ x, yindex, cover * (ONE_PIXEL * 2), cell->x - x);
+
+            cover += cell->cover;
+            area = cover * (ONE_PIXEL * 2) - cell->area;
+
+            if (area != 0 && cell->x >= 0)
+                gray_hline(RAS_VAR_ cell->x, yindex, area, 1);
+
+            x = cell->x + 1;
+        }
+
+        if (ras.count_ex > x && cover != 0)
+            gray_hline(RAS_VAR_ x, yindex, cover * (ONE_PIXEL * 2), ras.count_ex - x);
+    }
+}
+
+/*************************************************************************/
+/*                                                                       */
+/*  The following function should only compile in stand_alone mode,      */
+/*  i.e., when building this component without the rest of FreeType.     */
+/*                                                                       */
+/*************************************************************************/
+
+/*************************************************************************/
+/*                                                                       */
+/* <Function>                                                            */
+/*    PVG_FT_Outline_Decompose                                               */
+/*                                                                       */
+/* <Description>                                                         */
+/*    Walks over an outline's structure to decompose it into individual  */
+/*    segments and Bezier arcs.  This function is also able to emit      */
+/*    `move to' and `close to' operations to indicate the start and end  */
+/*    of new contours in the outline.                                    */
+/*                                                                       */
+/* <Input>                                                               */
+/*    outline        :: A pointer to the source target.                  */
+/*                                                                       */
+/*    user           :: A typeless pointer which is passed to each       */
+/*                      emitter during the decomposition.  It can be     */
+/*                      used to store the state during the               */
+/*                      decomposition.                                   */
+/*                                                                       */
+/* <Return>                                                              */
+/*    Error code.  0 means success.                                      */
+/*                                                                       */
+static int PVG_FT_Outline_Decompose(const PVG_FT_Outline* outline, void* user)
+{
+#undef SCALED
+#define SCALED(x) (x)
+
+    PVG_FT_Vector v_last;
+    PVG_FT_Vector v_control;
+    PVG_FT_Vector v_start;
+
+    PVG_FT_Vector* point;
+    PVG_FT_Vector* limit;
+    char* tags;
+
+    int n;     /* index of contour in outline     */
+    int first; /* index of first point in contour */
+    int error;
+    char tag; /* current point's state           */
+
+    if (!outline)
+        return ErrRaster_Invalid_Outline;
+
+    first = 0;
+
+    for (n = 0; n < outline->n_contours; n++)
+    {
+        int last; /* index of last point in contour */
+
+        last = outline->contours[n];
+        if (last < 0)
+            goto Invalid_Outline;
+        limit = outline->points + last;
+
+        v_start = outline->points[first];
+        v_start.x = SCALED(v_start.x);
+        v_start.y = SCALED(v_start.y);
+
+        v_last = outline->points[last];
+        v_last.x = SCALED(v_last.x);
+        v_last.y = SCALED(v_last.y);
+
+        v_control = v_start;
+
+        point = outline->points + first;
+        tags = outline->tags + first;
+        tag = PVG_FT_CURVE_TAG(tags[0]);
+
+        /* A contour cannot start with a cubic control point! */
+        if (tag == PVG_FT_CURVE_TAG_CUBIC)
+            goto Invalid_Outline;
+
+        /* check first point to determine origin */
+        if (tag == PVG_FT_CURVE_TAG_CONIC)
+        {
+            /* first point is conic control.  Yes, this happens. */
+            if (PVG_FT_CURVE_TAG(outline->tags[last]) == PVG_FT_CURVE_TAG_ON)
+            {
+                /* start at last point if it is on the curve */
+                v_start = v_last;
+                limit--;
+            }
+            else
+            {
+                /* if both first and last points are conic,         */
+                /* start at their middle and record its position    */
+                /* for closure                                      */
+                v_start.x = (v_start.x + v_last.x) / 2;
+                v_start.y = (v_start.y + v_last.y) / 2;
+
+                v_last = v_start;
+            }
+            point--;
+            tags--;
+        }
+
+        error = gray_move_to(&v_start, static_cast<PWorker>(user));
+        if (error)
+            goto Exit;
+
+        while (point < limit)
+        {
+            point++;
+            tags++;
+
+            tag = PVG_FT_CURVE_TAG(tags[0]);
+            switch (tag)
+            {
+                case PVG_FT_CURVE_TAG_ON: /* emit a single line_to */
+                    {
+                        PVG_FT_Vector vec;
+
+                        vec.x = SCALED(point->x);
+                        vec.y = SCALED(point->y);
+
+                        gray_render_line(static_cast<PWorker>(user), UPSCALE(vec.x), UPSCALE(vec.y));
+                        continue;
+                    }
+
+                case PVG_FT_CURVE_TAG_CONIC: /* consume conic arcs */
+                    {
+                        v_control.x = SCALED(point->x);
+                        v_control.y = SCALED(point->y);
+
+                    Do_Conic:
+                        if (point < limit)
+                        {
+                            PVG_FT_Vector vec;
+                            PVG_FT_Vector v_middle;
+
+                            point++;
+                            tags++;
+                            tag = PVG_FT_CURVE_TAG(tags[0]);
+
+                            vec.x = SCALED(point->x);
+                            vec.y = SCALED(point->y);
+
+                            if (tag == PVG_FT_CURVE_TAG_ON)
+                            {
+                                gray_render_conic(static_cast<PWorker>(user), &v_control, &vec);
+                                continue;
+                            }
+
+                            if (tag != PVG_FT_CURVE_TAG_CONIC)
+                                goto Invalid_Outline;
+
+                            v_middle.x = (v_control.x + vec.x) / 2;
+                            v_middle.y = (v_control.y + vec.y) / 2;
+
+                            gray_render_conic(static_cast<PWorker>(user), &v_control, &v_middle);
+
+                            v_control = vec;
+                            goto Do_Conic;
+                        }
+
+                        gray_render_conic(static_cast<PWorker>(user), &v_control, &v_start);
+                        goto Close;
+                    }
+
+                default: /* PVG_FT_CURVE_TAG_CUBIC */
+                    {
+                        PVG_FT_Vector vec1, vec2;
+
+                        if (point + 1 > limit || PVG_FT_CURVE_TAG(tags[1]) != PVG_FT_CURVE_TAG_CUBIC)
+                            goto Invalid_Outline;
+
+                        point += 2;
+                        tags += 2;
+
+                        vec1.x = SCALED(point[-2].x);
+                        vec1.y = SCALED(point[-2].y);
+
+                        vec2.x = SCALED(point[-1].x);
+                        vec2.y = SCALED(point[-1].y);
+
+                        if (point <= limit)
+                        {
+                            PVG_FT_Vector vec;
+
+                            vec.x = SCALED(point->x);
+                            vec.y = SCALED(point->y);
+
+                            gray_render_cubic(static_cast<PWorker>(user), &vec1, &vec2, &vec);
+                            continue;
+                        }
+
+                        gray_render_cubic(static_cast<PWorker>(user), &vec1, &vec2, &v_start);
+                        goto Close;
+                    }
+            }
+        }
+
+        /* close the contour with a line segment */
+        gray_render_line(static_cast<PWorker>(user), UPSCALE(v_start.x), UPSCALE(v_start.y));
+
+    Close:
+        first = last + 1;
+    }
+
+    return 0;
+
+Exit:
+    return error;
+
+Invalid_Outline:
+    return ErrRaster_Invalid_Outline;
+}
+
+typedef struct TBand_
+{
+    TPos min, max;
+
+} TBand;
+
+static int gray_convert_glyph_inner(RAS_ARG)
+{
+    volatile int error = 0;
+
+    if (pvg_ft_setjmp(ras.jump_buffer) == 0)
+    {
+        error = PVG_FT_Outline_Decompose(&ras.outline, &ras);
+        if (!ras.invalid)
+            gray_record_cell(RAS_VAR);
+    }
+    else
+    {
+        error = ErrRaster_Memory_Overflow;
+    }
+
+    return error;
+}
+
+static int gray_convert_glyph(RAS_ARG)
+{
+    TBand bands[40];
+    TBand* volatile band;
+    int volatile n, num_bands;
+    TPos volatile min, max, max_y;
+    PVG_FT_BBox* clip;
+    int skip;
+
+    ras.num_gray_spans = 0;
+
+    /* Set up state in the raster object */
+    gray_compute_cbox(RAS_VAR);
+
+    /* clip to target bitmap, exit if nothing to do */
+    clip = &ras.clip_box;
+
+    if (ras.max_ex <= clip->xMin || ras.min_ex >= clip->xMax || ras.max_ey <= clip->yMin || ras.min_ey >= clip->yMax)
+        return 0;
+
+    if (ras.min_ex < clip->xMin)
+        ras.min_ex = clip->xMin;
+    if (ras.min_ey < clip->yMin)
+        ras.min_ey = clip->yMin;
+
+    if (ras.max_ex > clip->xMax)
+        ras.max_ex = clip->xMax;
+    if (ras.max_ey > clip->yMax)
+        ras.max_ey = clip->yMax;
+
+    ras.count_ex = ras.max_ex - ras.min_ex;
+    ras.count_ey = ras.max_ey - ras.min_ey;
+
+    /* set up vertical bands */
+    num_bands = (int) ((ras.max_ey - ras.min_ey) / ras.band_size);
+    if (num_bands == 0)
+        num_bands = 1;
+    if (num_bands >= 39)
+        num_bands = 39;
+
+    ras.band_shoot = 0;
+
+    min = ras.min_ey;
+    max_y = ras.max_ey;
+
+    for (n = 0; n < num_bands; n++, min = max)
+    {
+        max = min + ras.band_size;
+        if (n == num_bands - 1 || max > max_y)
+            max = max_y;
+
+        bands[0].min = min;
+        bands[0].max = max;
+        band = bands;
+
+        while (band >= bands)
+        {
+            TPos bottom, top, middle;
+            int error;
+
+            {
+                PCell cells_max;
+                int yindex;
+                int cell_start, cell_end, cell_mod;
+
+                ras.ycells = (PCell*) ras.buffer;
+                ras.ycount = band->max - band->min;
+
+                cell_start = sizeof(PCell) * ras.ycount;
+                cell_mod = cell_start % sizeof(TCell);
+                if (cell_mod > 0)
+                    cell_start += sizeof(TCell) - cell_mod;
+
+                cell_end = ras.buffer_size;
+                cell_end -= cell_end % sizeof(TCell);
+
+                cells_max = (PCell) ((char*) ras.buffer + cell_end);
+                ras.cells = (PCell) ((char*) ras.buffer + cell_start);
+                if (ras.cells >= cells_max)
+                    goto ReduceBands;
+
+                ras.max_cells = (int) (cells_max - ras.cells);
+                if (ras.max_cells < 2)
+                    goto ReduceBands;
+
+                for (yindex = 0; yindex < ras.ycount; yindex++)
+                    ras.ycells[yindex] = NULL;
+            }
+
+            ras.num_cells = 0;
+            ras.invalid = 1;
+            ras.min_ey = band->min;
+            ras.max_ey = band->max;
+            ras.count_ey = band->max - band->min;
+
+            error = gray_convert_glyph_inner(RAS_VAR);
+
+            if (!error)
+            {
+                gray_sweep(RAS_VAR);
+                band--;
+                continue;
+            }
+            else if (error != ErrRaster_Memory_Overflow)
+                return 1;
+
+        ReduceBands:
+            /* render pool overflow; we will reduce the render band by half */
+            bottom = band->min;
+            top = band->max;
+            middle = bottom + ((top - bottom) >> 1);
+
+            /* This is too complex for a single scanline; there must */
+            /* be some problems.                                     */
+            if (middle == bottom)
+            {
+                return ErrRaster_OutOfMemory;
+            }
+
+            if (bottom - top >= ras.band_size)
+                ras.band_shoot++;
+
+            band[1].min = bottom;
+            band[1].max = middle;
+            band[0].min = middle;
+            band[0].max = top;
+            band++;
+        }
+    }
+
+    if (ras.render_span && ras.num_gray_spans > ras.skip_spans)
+    {
+        skip = ras.skip_spans > 0 ? ras.skip_spans : 0;
+        ras.render_span(ras.num_gray_spans - skip, ras.gray_spans + skip, ras.render_span_data);
+    }
+
+    ras.skip_spans -= ras.num_gray_spans;
+
+    if (ras.band_shoot > 8 && ras.band_size > 16)
+        ras.band_size = ras.band_size / 2;
+
+    return 0;
+}
+
+static int gray_raster_render(RAS_ARG_ void* buffer, long buffer_size, const PVG_FT_Raster_Params* params)
+{
+    const PVG_FT_Outline* outline = (const PVG_FT_Outline*) params->source;
+    if (outline == NULL)
+        return ErrRaster_Invalid_Outline;
+
+    /* return immediately if the outline is empty */
+    if (outline->n_points == 0 || outline->n_contours <= 0)
+        return 0;
+
+    if (!outline->contours || !outline->points)
+        return ErrRaster_Invalid_Outline;
+
+    if (outline->n_points != outline->contours[outline->n_contours - 1] + 1)
+        return ErrRaster_Invalid_Outline;
+
+    /* this version does not support monochrome rendering */
+    if (!(params->flags & PVG_FT_RASTER_FLAG_AA))
+        return ErrRaster_Invalid_Mode;
+
+    if (!(params->flags & PVG_FT_RASTER_FLAG_DIRECT))
+        return ErrRaster_Invalid_Mode;
+
+    /* compute clipping box */
+    if (params->flags & PVG_FT_RASTER_FLAG_CLIP)
+    {
+        ras.clip_box = params->clip_box;
+    }
+    else
+    {
+        ras.clip_box.xMin = -(1 << 23);
+        ras.clip_box.yMin = -(1 << 23);
+        ras.clip_box.xMax = (1 << 23) - 1;
+        ras.clip_box.yMax = (1 << 23) - 1;
+    }
+
+    gray_init_cells(RAS_VAR_ buffer, buffer_size);
+
+    ras.outline = *outline;
+    ras.num_cells = 0;
+    ras.invalid = 1;
+    ras.band_size = (int) (buffer_size / (long) (sizeof(TCell) * 8));
+
+    ras.render_span = (PVG_FT_Raster_Span_Func) params->gray_spans;
+    ras.render_span_data = params->user;
+
+    return gray_convert_glyph(RAS_VAR);
+}
+
+void PVG_FT_Raster_Render(const PVG_FT_Raster_Params* params)
+{
+    char stack[PVG_FT_MINIMUM_POOL_SIZE];
+    long length = PVG_FT_MINIMUM_POOL_SIZE;
+
+    TWorker worker;
+    worker.skip_spans = 0;
+    int rendered_spans = 0;
+    int error = gray_raster_render(&worker, stack, length, params);
+    while (error == ErrRaster_OutOfMemory)
+    {
+        if (worker.skip_spans < 0)
+            rendered_spans += -worker.skip_spans;
+        worker.skip_spans = rendered_spans;
+        length *= 2;
+        void* heap = malloc((size_t) (length));
+        error = gray_raster_render(&worker, heap, length, params);
+        free(heap);
+    }
+}
+
+/* END */

--- a/source/plutovg/plutovg-ft-raster.h
+++ b/source/plutovg/plutovg-ft-raster.h
@@ -1,0 +1,420 @@
+/***************************************************************************/
+/*                                                                         */
+/*  ftimage.h                                                              */
+/*                                                                         */
+/*    FreeType glyph image formats and default raster interface            */
+/*    (specification).                                                     */
+/*                                                                         */
+/*  Copyright 1996-2010, 2013 by                                           */
+/*  David Turner, Robert Wilhelm, and Werner Lemberg.                      */
+/*                                                                         */
+/*  This file is part of the FreeType project, and may only be used,       */
+/*  modified, and distributed under the terms of the FreeType project      */
+/*  license, LICENSE.TXT.  By continuing to use, modify, or distribute     */
+/*  this file you indicate that you have read the license and              */
+/*  understand and accept it fully.                                        */
+/*                                                                         */
+/***************************************************************************/
+
+#ifndef PLUTOVG_FT_RASTER_H
+#define PLUTOVG_FT_RASTER_H
+
+#include "plutovg-ft-types.h"
+
+/*************************************************************************/
+/*                                                                       */
+/* <Struct>                                                              */
+/*    FT_BBox                                                            */
+/*                                                                       */
+/* <Description>                                                         */
+/*    A structure used to hold an outline's bounding box, i.e., the      */
+/*    coordinates of its extrema in the horizontal and vertical          */
+/*    directions.                                                        */
+/*                                                                       */
+/* <Fields>                                                              */
+/*    xMin :: The horizontal minimum (left-most).                        */
+/*                                                                       */
+/*    yMin :: The vertical minimum (bottom-most).                        */
+/*                                                                       */
+/*    xMax :: The horizontal maximum (right-most).                       */
+/*                                                                       */
+/*    yMax :: The vertical maximum (top-most).                           */
+/*                                                                       */
+/* <Note>                                                                */
+/*    The bounding box is specified with the coordinates of the lower    */
+/*    left and the upper right corner.  In PostScript, those values are  */
+/*    often called (llx,lly) and (urx,ury), respectively.                */
+/*                                                                       */
+/*    If `yMin' is negative, this value gives the glyph's descender.     */
+/*    Otherwise, the glyph doesn't descend below the baseline.           */
+/*    Similarly, if `ymax' is positive, this value gives the glyph's     */
+/*    ascender.                                                          */
+/*                                                                       */
+/*    `xMin' gives the horizontal distance from the glyph's origin to    */
+/*    the left edge of the glyph's bounding box.  If `xMin' is negative, */
+/*    the glyph extends to the left of the origin.                       */
+/*                                                                       */
+typedef struct  PVG_FT_BBox_
+{
+    PVG_FT_Pos  xMin, yMin;
+    PVG_FT_Pos  xMax, yMax;
+
+} PVG_FT_BBox;
+
+/*************************************************************************/
+/*                                                                       */
+/* <Struct>                                                              */
+/*    PVG_FT_Outline                                                      */
+/*                                                                       */
+/* <Description>                                                         */
+/*    This structure is used to describe an outline to the scan-line     */
+/*    converter.                                                         */
+/*                                                                       */
+/* <Fields>                                                              */
+/*    n_contours :: The number of contours in the outline.               */
+/*                                                                       */
+/*    n_points   :: The number of points in the outline.                 */
+/*                                                                       */
+/*    points     :: A pointer to an array of `n_points' @PVG_FT_Vector    */
+/*                  elements, giving the outline's point coordinates.    */
+/*                                                                       */
+/*    tags       :: A pointer to an array of `n_points' chars, giving    */
+/*                  each outline point's type.                           */
+/*                                                                       */
+/*                  If bit~0 is unset, the point is `off' the curve,     */
+/*                  i.e., a Bézier control point, while it is `on' if    */
+/*                  set.                                                 */
+/*                                                                       */
+/*                  Bit~1 is meaningful for `off' points only.  If set,  */
+/*                  it indicates a third-order Bézier arc control point; */
+/*                  and a second-order control point if unset.           */
+/*                                                                       */
+/*                  If bit~2 is set, bits 5-7 contain the drop-out mode  */
+/*                  (as defined in the OpenType specification; the value */
+/*                  is the same as the argument to the SCANMODE          */
+/*                  instruction).                                        */
+/*                                                                       */
+/*                  Bits 3 and~4 are reserved for internal purposes.     */
+/*                                                                       */
+/*    contours   :: An array of `n_contours' shorts, giving the end      */
+/*                  point of each contour within the outline.  For       */
+/*                  example, the first contour is defined by the points  */
+/*                  `0' to `contours[0]', the second one is defined by   */
+/*                  the points `contours[0]+1' to `contours[1]', etc.    */
+/*                                                                       */
+/*    flags      :: A set of bit flags used to characterize the outline  */
+/*                  and give hints to the scan-converter and hinter on   */
+/*                  how to convert/grid-fit it.  See @PVG_FT_OUTLINE_FLAGS.*/
+/*                                                                       */
+typedef struct  PVG_FT_Outline_
+{
+    int       n_contours;      /* number of contours in glyph        */
+    int       n_points;        /* number of points in the glyph      */
+
+    PVG_FT_Vector*  points;          /* the outline's points               */
+    char*       tags;            /* the points flags                   */
+    int*      contours;        /* the contour end points             */
+    char*       contours_flag;   /* the contour open flags             */
+
+    int         flags;           /* outline masks                      */
+
+} PVG_FT_Outline;
+
+
+/*************************************************************************/
+/*                                                                       */
+/* <Enum>                                                                */
+/*    PVG_FT_OUTLINE_FLAGS                                                   */
+/*                                                                       */
+/* <Description>                                                         */
+/*    A list of bit-field constants use for the flags in an outline's    */
+/*    `flags' field.                                                     */
+/*                                                                       */
+/* <Values>                                                              */
+/*    PVG_FT_OUTLINE_NONE ::                                                 */
+/*      Value~0 is reserved.                                             */
+/*                                                                       */
+/*    PVG_FT_OUTLINE_OWNER ::                                                */
+/*      If set, this flag indicates that the outline's field arrays      */
+/*      (i.e., `points', `flags', and `contours') are `owned' by the     */
+/*      outline object, and should thus be freed when it is destroyed.   */
+/*                                                                       */
+/*    PVG_FT_OUTLINE_EVEN_ODD_FILL ::                                        */
+/*      By default, outlines are filled using the non-zero winding rule. */
+/*      If set to 1, the outline will be filled using the even-odd fill  */
+/*      rule (only works with the smooth rasterizer).                    */
+/*                                                                       */
+/*    PVG_FT_OUTLINE_REVERSE_FILL ::                                         */
+/*      By default, outside contours of an outline are oriented in       */
+/*      clock-wise direction, as defined in the TrueType specification.  */
+/*      This flag is set if the outline uses the opposite direction      */
+/*      (typically for Type~1 fonts).  This flag is ignored by the scan  */
+/*      converter.                                                       */
+/*                                                                       */
+/*                                                                       */
+/*                                                                       */
+/*    There exists a second mechanism to pass the drop-out mode to the   */
+/*    B/W rasterizer; see the `tags' field in @PVG_FT_Outline.               */
+/*                                                                       */
+/*    Please refer to the description of the `SCANTYPE' instruction in   */
+/*    the OpenType specification (in file `ttinst1.doc') how simple      */
+/*    drop-outs, smart drop-outs, and stubs are defined.                 */
+/*                                                                       */
+#define PVG_FT_OUTLINE_NONE             0x0
+#define PVG_FT_OUTLINE_OWNER            0x1
+#define PVG_FT_OUTLINE_EVEN_ODD_FILL    0x2
+#define PVG_FT_OUTLINE_REVERSE_FILL     0x4
+
+/* */
+
+#define PVG_FT_CURVE_TAG( flag )  ( flag & 3 )
+
+#define PVG_FT_CURVE_TAG_ON            1
+#define PVG_FT_CURVE_TAG_CONIC         0
+#define PVG_FT_CURVE_TAG_CUBIC         2
+
+
+#define PVG_FT_Curve_Tag_On       PVG_FT_CURVE_TAG_ON
+#define PVG_FT_Curve_Tag_Conic    PVG_FT_CURVE_TAG_CONIC
+#define PVG_FT_Curve_Tag_Cubic    PVG_FT_CURVE_TAG_CUBIC
+
+/*************************************************************************/
+/*                                                                       */
+/* <Function>                                                            */
+/*    PVG_FT_Outline_Check                                                   */
+/*                                                                       */
+/* <Description>                                                         */
+/*    Check the contents of an outline descriptor.                       */
+/*                                                                       */
+/* <Input>                                                               */
+/*    outline :: A handle to a source outline.                           */
+/*                                                                       */
+/* <Return>                                                              */
+/*    FreeType error code.  0~means success.                             */
+/*                                                                       */
+PVG_FT_Error
+PVG_FT_Outline_Check( PVG_FT_Outline*  outline );
+
+
+/*************************************************************************/
+/*                                                                       */
+/* <Function>                                                            */
+/*    PVG_FT_Outline_Get_CBox                                                */
+/*                                                                       */
+/* <Description>                                                         */
+/*    Return an outline's `control box'.  The control box encloses all   */
+/*    the outline's points, including Bézier control points.  Though it  */
+/*    coincides with the exact bounding box for most glyphs, it can be   */
+/*    slightly larger in some situations (like when rotating an outline  */
+/*    that contains Bézier outside arcs).                                */
+/*                                                                       */
+/*    Computing the control box is very fast, while getting the bounding */
+/*    box can take much more time as it needs to walk over all segments  */
+/*    and arcs in the outline.  To get the latter, you can use the       */
+/*    `ftbbox' component, which is dedicated to this single task.        */
+/*                                                                       */
+/* <Input>                                                               */
+/*    outline :: A pointer to the source outline descriptor.             */
+/*                                                                       */
+/* <Output>                                                              */
+/*    acbox   :: The outline's control box.                              */
+/*                                                                       */
+/* <Note>                                                                */
+/*    See @PVG_FT_Glyph_Get_CBox for a discussion of tricky fonts.           */
+/*                                                                       */
+void
+PVG_FT_Outline_Get_CBox( const PVG_FT_Outline*  outline,
+    PVG_FT_BBox           *acbox );
+
+/*************************************************************************/
+/*                                                                       */
+/* <Struct>                                                              */
+/*    PVG_FT_Span                                                            */
+/*                                                                       */
+/* <Description>                                                         */
+/*    A structure used to model a single span of gray (or black) pixels  */
+/*    when rendering a monochrome or anti-aliased bitmap.                */
+/*                                                                       */
+/* <Fields>                                                              */
+/*    x        :: The span's horizontal start position.                  */
+/*                                                                       */
+/*    len      :: The span's length in pixels.                           */
+/*                                                                       */
+/*    coverage :: The span color/coverage, ranging from 0 (background)   */
+/*                to 255 (foreground).  Only used for anti-aliased       */
+/*                rendering.                                             */
+/*                                                                       */
+/* <Note>                                                                */
+/*    This structure is used by the span drawing callback type named     */
+/*    @PVG_FT_SpanFunc that takes the y~coordinate of the span as a          */
+/*    parameter.                                                         */
+/*                                                                       */
+/*    The coverage value is always between 0 and 255.  If you want less  */
+/*    gray values, the callback function has to reduce them.             */
+/*                                                                       */
+typedef struct  PVG_FT_Span_
+{
+    int x;
+    int len;
+    int y;
+    unsigned char coverage;
+
+} PVG_FT_Span;
+
+
+/*************************************************************************/
+/*                                                                       */
+/* <FuncType>                                                            */
+/*    PVG_FT_SpanFunc                                                        */
+/*                                                                       */
+/* <Description>                                                         */
+/*    A function used as a call-back by the anti-aliased renderer in     */
+/*    order to let client applications draw themselves the gray pixel    */
+/*    spans on each scan line.                                           */
+/*                                                                       */
+/* <Input>                                                               */
+/*    y     :: The scanline's y~coordinate.                              */
+/*                                                                       */
+/*    count :: The number of spans to draw on this scanline.             */
+/*                                                                       */
+/*    spans :: A table of `count' spans to draw on the scanline.         */
+/*                                                                       */
+/*    user  :: User-supplied data that is passed to the callback.        */
+/*                                                                       */
+/* <Note>                                                                */
+/*    This callback allows client applications to directly render the    */
+/*    gray spans of the anti-aliased bitmap to any kind of surfaces.     */
+/*                                                                       */
+/*    This can be used to write anti-aliased outlines directly to a      */
+/*    given background bitmap, and even perform translucency.            */
+/*                                                                       */
+/*    Note that the `count' field cannot be greater than a fixed value   */
+/*    defined by the `PVG_FT_MAX_GRAY_SPANS' configuration macro in          */
+/*    `ftoption.h'.  By default, this value is set to~32, which means    */
+/*    that if there are more than 32~spans on a given scanline, the      */
+/*    callback is called several times with the same `y' parameter in    */
+/*    order to draw all callbacks.                                       */
+/*                                                                       */
+/*    Otherwise, the callback is only called once per scan-line, and     */
+/*    only for those scanlines that do have `gray' pixels on them.       */
+/*                                                                       */
+typedef void
+    (*PVG_FT_SpanFunc)( int             count,
+        const PVG_FT_Span*  spans,
+        void*           user );
+
+#define PVG_FT_Raster_Span_Func  PVG_FT_SpanFunc
+
+
+
+/*************************************************************************/
+/*                                                                       */
+/* <Enum>                                                                */
+/*    PVG_FT_RASTER_FLAG_XXX                                                 */
+/*                                                                       */
+/* <Description>                                                         */
+/*    A list of bit flag constants as used in the `flags' field of a     */
+/*    @PVG_FT_Raster_Params structure.                                       */
+/*                                                                       */
+/* <Values>                                                              */
+/*    PVG_FT_RASTER_FLAG_DEFAULT :: This value is 0.                         */
+/*                                                                       */
+/*    PVG_FT_RASTER_FLAG_AA      :: This flag is set to indicate that an     */
+/*                              anti-aliased glyph image should be       */
+/*                              generated.  Otherwise, it will be        */
+/*                              monochrome (1-bit).                      */
+/*                                                                       */
+/*    PVG_FT_RASTER_FLAG_DIRECT  :: This flag is set to indicate direct      */
+/*                              rendering.  In this mode, client         */
+/*                              applications must provide their own span */
+/*                              callback.  This lets them directly       */
+/*                              draw or compose over an existing bitmap. */
+/*                              If this bit is not set, the target       */
+/*                              pixmap's buffer _must_ be zeroed before  */
+/*                              rendering.                               */
+/*                                                                       */
+/*                              Note that for now, direct rendering is   */
+/*                              only possible with anti-aliased glyphs.  */
+/*                                                                       */
+/*    PVG_FT_RASTER_FLAG_CLIP    :: This flag is only used in direct         */
+/*                              rendering mode.  If set, the output will */
+/*                              be clipped to a box specified in the     */
+/*                              `clip_box' field of the                  */
+/*                              @PVG_FT_Raster_Params structure.             */
+/*                                                                       */
+/*                              Note that by default, the glyph bitmap   */
+/*                              is clipped to the target pixmap, except  */
+/*                              in direct rendering mode where all spans */
+/*                              are generated if no clipping box is set. */
+/*                                                                       */
+#define PVG_FT_RASTER_FLAG_DEFAULT  0x0
+#define PVG_FT_RASTER_FLAG_AA       0x1
+#define PVG_FT_RASTER_FLAG_DIRECT   0x2
+#define PVG_FT_RASTER_FLAG_CLIP     0x4
+
+
+/*************************************************************************/
+/*                                                                       */
+/* <Struct>                                                              */
+/*    PVG_FT_Raster_Params                                                   */
+/*                                                                       */
+/* <Description>                                                         */
+/*    A structure to hold the arguments used by a raster's render        */
+/*    function.                                                          */
+/*                                                                       */
+/* <Fields>                                                              */
+/*    target      :: The target bitmap.                                  */
+/*                                                                       */
+/*    source      :: A pointer to the source glyph image (e.g., an       */
+/*                   @PVG_FT_Outline).                                       */
+/*                                                                       */
+/*    flags       :: The rendering flags.                                */
+/*                                                                       */
+/*    gray_spans  :: The gray span drawing callback.                     */
+/*                                                                       */
+/*    black_spans :: The black span drawing callback.  UNIMPLEMENTED!    */
+/*                                                                       */
+/*    bit_test    :: The bit test callback.  UNIMPLEMENTED!              */
+/*                                                                       */
+/*    bit_set     :: The bit set callback.  UNIMPLEMENTED!               */
+/*                                                                       */
+/*    user        :: User-supplied data that is passed to each drawing   */
+/*                   callback.                                           */
+/*                                                                       */
+/*    clip_box    :: An optional clipping box.  It is only used in       */
+/*                   direct rendering mode.  Note that coordinates here  */
+/*                   should be expressed in _integer_ pixels (and not in */
+/*                   26.6 fixed-point units).                            */
+/*                                                                       */
+/* <Note>                                                                */
+/*    An anti-aliased glyph bitmap is drawn if the @PVG_FT_RASTER_FLAG_AA    */
+/*    bit flag is set in the `flags' field, otherwise a monochrome       */
+/*    bitmap is generated.                                               */
+/*                                                                       */
+/*    If the @PVG_FT_RASTER_FLAG_DIRECT bit flag is set in `flags', the      */
+/*    raster will call the `gray_spans' callback to draw gray pixel      */
+/*    spans, in the case of an aa glyph bitmap, it will call             */
+/*    `black_spans', and `bit_test' and `bit_set' in the case of a       */
+/*    monochrome bitmap.  This allows direct composition over a          */
+/*    pre-existing bitmap through user-provided callbacks to perform the */
+/*    span drawing/composition.                                          */
+/*                                                                       */
+/*    Note that the `bit_test' and `bit_set' callbacks are required when */
+/*    rendering a monochrome bitmap, as they are crucial to implement    */
+/*    correct drop-out control as defined in the TrueType specification. */
+/*                                                                       */
+typedef struct  PVG_FT_Raster_Params_
+{
+    const void*             source;
+    int                     flags;
+    PVG_FT_SpanFunc          gray_spans;
+    void*                   user;
+    PVG_FT_BBox              clip_box;
+
+} PVG_FT_Raster_Params;
+
+
+void
+PVG_FT_Raster_Render(const PVG_FT_Raster_Params *params);
+
+#endif // PLUTOVG_FT_RASTER_H

--- a/source/plutovg/plutovg-ft-stroker.cpp
+++ b/source/plutovg/plutovg-ft-stroker.cpp
@@ -1,0 +1,1947 @@
+
+/***************************************************************************/
+/*                                                                         */
+/*  ftstroke.c                                                             */
+/*                                                                         */
+/*    FreeType path stroker (body).                                        */
+/*                                                                         */
+/*  Copyright 2002-2006, 2008-2011, 2013 by                                */
+/*  David Turner, Robert Wilhelm, and Werner Lemberg.                      */
+/*                                                                         */
+/*  This file is part of the FreeType project, and may only be used,       */
+/*  modified, and distributed under the terms of the FreeType project      */
+/*  license, LICENSE.TXT.  By continuing to use, modify, or distribute     */
+/*  this file you indicate that you have read the license and              */
+/*  understand and accept it fully.                                        */
+/*                                                                         */
+/***************************************************************************/
+
+#include "plutovg-ft-stroker.h"
+#include "plutovg-ft-math.h"
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*************************************************************************/
+/*************************************************************************/
+/*****                                                               *****/
+/*****                      BEZIER COMPUTATIONS                      *****/
+/*****                                                               *****/
+/*************************************************************************/
+/*************************************************************************/
+
+#define PVG_FT_SMALL_CONIC_THRESHOLD (PVG_FT_ANGLE_PI / 6)
+#define PVG_FT_SMALL_CUBIC_THRESHOLD (PVG_FT_ANGLE_PI / 8)
+
+#define PVG_FT_EPSILON 2
+
+#define PVG_FT_IS_SMALL(x) ((x) > -PVG_FT_EPSILON && (x) < PVG_FT_EPSILON)
+
+static PVG_FT_Pos ft_pos_abs(PVG_FT_Pos x)
+{
+    return x >= 0 ? x : -x;
+}
+
+static void ft_conic_split(PVG_FT_Vector* base)
+{
+    PVG_FT_Pos a, b;
+
+    base[4].x = base[2].x;
+    a = base[0].x + base[1].x;
+    b = base[1].x + base[2].x;
+    base[3].x = b >> 1;
+    base[2].x = ( a + b ) >> 2;
+    base[1].x = a >> 1;
+
+    base[4].y = base[2].y;
+    a = base[0].y + base[1].y;
+    b = base[1].y + base[2].y;
+    base[3].y = b >> 1;
+    base[2].y = ( a + b ) >> 2;
+    base[1].y = a >> 1;
+}
+
+static PVG_FT_Bool ft_conic_is_small_enough(PVG_FT_Vector* base,
+                                           PVG_FT_Angle*  angle_in,
+                                           PVG_FT_Angle*  angle_out)
+{
+    PVG_FT_Vector d1, d2;
+    PVG_FT_Angle  theta;
+    PVG_FT_Int    close1, close2;
+
+    d1.x = base[1].x - base[2].x;
+    d1.y = base[1].y - base[2].y;
+    d2.x = base[0].x - base[1].x;
+    d2.y = base[0].y - base[1].y;
+
+    close1 = PVG_FT_IS_SMALL(d1.x) && PVG_FT_IS_SMALL(d1.y);
+    close2 = PVG_FT_IS_SMALL(d2.x) && PVG_FT_IS_SMALL(d2.y);
+
+    if (close1) {
+        if (close2) {
+            /* basically a point;                      */
+            /* do nothing to retain original direction */
+        } else {
+            *angle_in = *angle_out = PVG_FT_Atan2(d2.x, d2.y);
+        }
+    } else /* !close1 */
+    {
+        if (close2) {
+            *angle_in = *angle_out = PVG_FT_Atan2(d1.x, d1.y);
+        } else {
+            *angle_in = PVG_FT_Atan2(d1.x, d1.y);
+            *angle_out = PVG_FT_Atan2(d2.x, d2.y);
+        }
+    }
+
+    theta = ft_pos_abs(PVG_FT_Angle_Diff(*angle_in, *angle_out));
+
+    return PVG_FT_BOOL(theta < PVG_FT_SMALL_CONIC_THRESHOLD);
+}
+
+static void ft_cubic_split(PVG_FT_Vector* base)
+{
+    PVG_FT_Pos a, b, c;
+
+    base[6].x = base[3].x;
+    a = base[0].x + base[1].x;
+    b = base[1].x + base[2].x;
+    c = base[2].x + base[3].x;
+    base[5].x = c >> 1;
+    c += b;
+    base[4].x = c >> 2;
+    base[1].x = a >> 1;
+    a += b;
+    base[2].x = a >> 2;
+    base[3].x = ( a + c ) >> 3;
+
+    base[6].y = base[3].y;
+    a = base[0].y + base[1].y;
+    b = base[1].y + base[2].y;
+    c = base[2].y + base[3].y;
+    base[5].y = c >> 1;
+    c += b;
+    base[4].y = c >> 2;
+    base[1].y = a >> 1;
+    a += b;
+    base[2].y = a >> 2;
+    base[3].y = ( a + c ) >> 3;
+}
+
+/* Return the average of `angle1' and `angle2'.            */
+/* This gives correct result even if `angle1' and `angle2' */
+/* have opposite signs.                                    */
+static PVG_FT_Angle ft_angle_mean(PVG_FT_Angle angle1, PVG_FT_Angle angle2)
+{
+    return angle1 + PVG_FT_Angle_Diff(angle1, angle2) / 2;
+}
+
+static PVG_FT_Bool ft_cubic_is_small_enough(PVG_FT_Vector* base,
+                                           PVG_FT_Angle*  angle_in,
+                                           PVG_FT_Angle*  angle_mid,
+                                           PVG_FT_Angle*  angle_out)
+{
+    PVG_FT_Vector d1, d2, d3;
+    PVG_FT_Angle  theta1, theta2;
+    PVG_FT_Int    close1, close2, close3;
+
+    d1.x = base[2].x - base[3].x;
+    d1.y = base[2].y - base[3].y;
+    d2.x = base[1].x - base[2].x;
+    d2.y = base[1].y - base[2].y;
+    d3.x = base[0].x - base[1].x;
+    d3.y = base[0].y - base[1].y;
+
+    close1 = PVG_FT_IS_SMALL(d1.x) && PVG_FT_IS_SMALL(d1.y);
+    close2 = PVG_FT_IS_SMALL(d2.x) && PVG_FT_IS_SMALL(d2.y);
+    close3 = PVG_FT_IS_SMALL(d3.x) && PVG_FT_IS_SMALL(d3.y);
+
+    if (close1) {
+        if (close2) {
+            if (close3) {
+                /* basically a point;                      */
+                /* do nothing to retain original direction */
+            } else /* !close3 */
+            {
+                *angle_in = *angle_mid = *angle_out = PVG_FT_Atan2(d3.x, d3.y);
+            }
+        } else /* !close2 */
+        {
+            if (close3) {
+                *angle_in = *angle_mid = *angle_out = PVG_FT_Atan2(d2.x, d2.y);
+            } else /* !close3 */
+            {
+                *angle_in = *angle_mid = PVG_FT_Atan2(d2.x, d2.y);
+                *angle_out = PVG_FT_Atan2(d3.x, d3.y);
+            }
+        }
+    } else /* !close1 */
+    {
+        if (close2) {
+            if (close3) {
+                *angle_in = *angle_mid = *angle_out = PVG_FT_Atan2(d1.x, d1.y);
+            } else /* !close3 */
+            {
+                *angle_in = PVG_FT_Atan2(d1.x, d1.y);
+                *angle_out = PVG_FT_Atan2(d3.x, d3.y);
+                *angle_mid = ft_angle_mean(*angle_in, *angle_out);
+            }
+        } else /* !close2 */
+        {
+            if (close3) {
+                *angle_in = PVG_FT_Atan2(d1.x, d1.y);
+                *angle_mid = *angle_out = PVG_FT_Atan2(d2.x, d2.y);
+            } else /* !close3 */
+            {
+                *angle_in = PVG_FT_Atan2(d1.x, d1.y);
+                *angle_mid = PVG_FT_Atan2(d2.x, d2.y);
+                *angle_out = PVG_FT_Atan2(d3.x, d3.y);
+            }
+        }
+    }
+
+    theta1 = ft_pos_abs(PVG_FT_Angle_Diff(*angle_in, *angle_mid));
+    theta2 = ft_pos_abs(PVG_FT_Angle_Diff(*angle_mid, *angle_out));
+
+    return PVG_FT_BOOL(theta1 < PVG_FT_SMALL_CUBIC_THRESHOLD &&
+                      theta2 < PVG_FT_SMALL_CUBIC_THRESHOLD);
+}
+
+/*************************************************************************/
+/*************************************************************************/
+/*****                                                               *****/
+/*****                       STROKE BORDERS                          *****/
+/*****                                                               *****/
+/*************************************************************************/
+/*************************************************************************/
+
+typedef enum PVG_FT_StrokeTags_ {
+    PVG_FT_STROKE_TAG_ON = 1,    /* on-curve point  */
+    PVG_FT_STROKE_TAG_CUBIC = 2, /* cubic off-point */
+    PVG_FT_STROKE_TAG_BEGIN = 4, /* sub-path start  */
+    PVG_FT_STROKE_TAG_END = 8    /* sub-path end    */
+
+} PVG_FT_StrokeTags;
+
+#define PVG_FT_STROKE_TAG_BEGIN_END \
+    (PVG_FT_STROKE_TAG_BEGIN | PVG_FT_STROKE_TAG_END)
+
+typedef struct PVG_FT_StrokeBorderRec_ {
+    PVG_FT_UInt    num_points;
+    PVG_FT_UInt    max_points;
+    PVG_FT_Vector* points;
+    PVG_FT_Byte*   tags;
+    PVG_FT_Bool    movable; /* TRUE for ends of lineto borders */
+    PVG_FT_Int     start;   /* index of current sub-path start point */
+    PVG_FT_Bool    valid;
+
+} PVG_FT_StrokeBorderRec, *PVG_FT_StrokeBorder;
+
+PVG_FT_Error PVG_FT_Outline_Check(PVG_FT_Outline* outline)
+{
+    if (outline) {
+        PVG_FT_Int n_points = outline->n_points;
+        PVG_FT_Int n_contours = outline->n_contours;
+        PVG_FT_Int end0, end;
+        PVG_FT_Int n;
+
+        /* empty glyph? */
+        if (n_points == 0 && n_contours == 0) return 0;
+
+        /* check point and contour counts */
+        if (n_points <= 0 || n_contours <= 0) goto Bad;
+
+        end0 = end = -1;
+        for (n = 0; n < n_contours; n++) {
+            end = outline->contours[n];
+
+            /* note that we don't accept empty contours */
+            if (end <= end0 || end >= n_points) goto Bad;
+
+            end0 = end;
+        }
+
+        if (end != n_points - 1) goto Bad;
+
+        /* XXX: check the tags array */
+        return 0;
+    }
+
+Bad:
+    return -1;  // PVG_FT_THROW( Invalid_Argument );
+}
+
+void PVG_FT_Outline_Get_CBox(const PVG_FT_Outline* outline, PVG_FT_BBox* acbox)
+{
+    PVG_FT_Pos xMin, yMin, xMax, yMax;
+
+    if (outline && acbox) {
+        if (outline->n_points == 0) {
+            xMin = 0;
+            yMin = 0;
+            xMax = 0;
+            yMax = 0;
+        } else {
+            PVG_FT_Vector* vec = outline->points;
+            PVG_FT_Vector* limit = vec + outline->n_points;
+
+            xMin = xMax = vec->x;
+            yMin = yMax = vec->y;
+            vec++;
+
+            for (; vec < limit; vec++) {
+                PVG_FT_Pos x, y;
+
+                x = vec->x;
+                if (x < xMin) xMin = x;
+                if (x > xMax) xMax = x;
+
+                y = vec->y;
+                if (y < yMin) yMin = y;
+                if (y > yMax) yMax = y;
+            }
+        }
+        acbox->xMin = xMin;
+        acbox->xMax = xMax;
+        acbox->yMin = yMin;
+        acbox->yMax = yMax;
+    }
+}
+
+static PVG_FT_Error ft_stroke_border_grow(PVG_FT_StrokeBorder border,
+                                         PVG_FT_UInt         new_points)
+{
+    PVG_FT_UInt  old_max = border->max_points;
+    PVG_FT_UInt  new_max = border->num_points + new_points;
+    PVG_FT_Error error = 0;
+
+    if (new_max > old_max) {
+        PVG_FT_UInt cur_max = old_max;
+
+        while (cur_max < new_max) cur_max += (cur_max >> 1) + 16;
+
+        border->points = (PVG_FT_Vector*)realloc(border->points,
+                                                cur_max * sizeof(PVG_FT_Vector));
+        border->tags =
+            (PVG_FT_Byte*)realloc(border->tags, cur_max * sizeof(PVG_FT_Byte));
+
+        if (!border->points || !border->tags) goto Exit;
+
+        border->max_points = cur_max;
+    }
+
+Exit:
+    return error;
+}
+
+static void ft_stroke_border_close(PVG_FT_StrokeBorder border,
+                                   PVG_FT_Bool         reverse)
+{
+    PVG_FT_UInt start = border->start;
+    PVG_FT_UInt count = border->num_points;
+
+    assert(border->start >= 0);
+
+    /* don't record empty paths! */
+    if (count <= start + 1U)
+        border->num_points = start;
+    else {
+        /* copy the last point to the start of this sub-path, since */
+        /* it contains the `adjusted' starting coordinates          */
+        border->num_points = --count;
+        border->points[start] = border->points[count];
+        border->tags[start]   = border->tags[count];
+
+        if (reverse) {
+            /* reverse the points */
+            {
+                PVG_FT_Vector* vec1 = border->points + start + 1;
+                PVG_FT_Vector* vec2 = border->points + count - 1;
+
+                for (; vec1 < vec2; vec1++, vec2--) {
+                    PVG_FT_Vector tmp;
+
+                    tmp = *vec1;
+                    *vec1 = *vec2;
+                    *vec2 = tmp;
+                }
+            }
+
+            /* then the tags */
+            {
+                PVG_FT_Byte* tag1 = border->tags + start + 1;
+                PVG_FT_Byte* tag2 = border->tags + count - 1;
+
+                for (; tag1 < tag2; tag1++, tag2--) {
+                    PVG_FT_Byte tmp;
+
+                    tmp = *tag1;
+                    *tag1 = *tag2;
+                    *tag2 = tmp;
+                }
+            }
+        }
+
+        border->tags[start] |= PVG_FT_STROKE_TAG_BEGIN;
+        border->tags[count - 1] |= PVG_FT_STROKE_TAG_END;
+    }
+
+    border->start = -1;
+    border->movable = FALSE;
+}
+
+static PVG_FT_Error ft_stroke_border_lineto(PVG_FT_StrokeBorder border,
+                                           PVG_FT_Vector* to, PVG_FT_Bool movable)
+{
+    PVG_FT_Error error = 0;
+
+    assert(border->start >= 0);
+
+    if (border->movable) {
+        /* move last point */
+        border->points[border->num_points - 1] = *to;
+    } else {
+        /* don't add zero-length lineto */
+        if (border->num_points > 0 &&
+            PVG_FT_IS_SMALL(border->points[border->num_points - 1].x - to->x) &&
+            PVG_FT_IS_SMALL(border->points[border->num_points - 1].y - to->y))
+            return error;
+
+        /* add one point */
+        error = ft_stroke_border_grow(border, 1);
+        if (!error) {
+            PVG_FT_Vector* vec = border->points + border->num_points;
+            PVG_FT_Byte*   tag = border->tags + border->num_points;
+
+            vec[0] = *to;
+            tag[0] = PVG_FT_STROKE_TAG_ON;
+
+            border->num_points += 1;
+        }
+    }
+    border->movable = movable;
+    return error;
+}
+
+static PVG_FT_Error ft_stroke_border_conicto(PVG_FT_StrokeBorder border,
+                                            PVG_FT_Vector*      control,
+                                            PVG_FT_Vector*      to)
+{
+    PVG_FT_Error error;
+
+    assert(border->start >= 0);
+
+    error = ft_stroke_border_grow(border, 2);
+    if (!error) {
+        PVG_FT_Vector* vec = border->points + border->num_points;
+        PVG_FT_Byte*   tag = border->tags + border->num_points;
+
+        vec[0] = *control;
+        vec[1] = *to;
+
+        tag[0] = 0;
+        tag[1] = PVG_FT_STROKE_TAG_ON;
+
+        border->num_points += 2;
+    }
+
+    border->movable = FALSE;
+
+    return error;
+}
+
+static PVG_FT_Error ft_stroke_border_cubicto(PVG_FT_StrokeBorder border,
+                                            PVG_FT_Vector*      control1,
+                                            PVG_FT_Vector*      control2,
+                                            PVG_FT_Vector*      to)
+{
+    PVG_FT_Error error;
+
+    assert(border->start >= 0);
+
+    error = ft_stroke_border_grow(border, 3);
+    if (!error) {
+        PVG_FT_Vector* vec = border->points + border->num_points;
+        PVG_FT_Byte*   tag = border->tags + border->num_points;
+
+        vec[0] = *control1;
+        vec[1] = *control2;
+        vec[2] = *to;
+
+        tag[0] = PVG_FT_STROKE_TAG_CUBIC;
+        tag[1] = PVG_FT_STROKE_TAG_CUBIC;
+        tag[2] = PVG_FT_STROKE_TAG_ON;
+
+        border->num_points += 3;
+    }
+
+    border->movable = FALSE;
+
+    return error;
+}
+
+#define PVG_FT_ARC_CUBIC_ANGLE (PVG_FT_ANGLE_PI / 2)
+
+
+static PVG_FT_Error
+ft_stroke_border_arcto( PVG_FT_StrokeBorder  border,
+                        PVG_FT_Vector*       center,
+                        PVG_FT_Fixed         radius,
+                        PVG_FT_Angle         angle_start,
+                        PVG_FT_Angle         angle_diff )
+{
+    PVG_FT_Fixed   coef;
+    PVG_FT_Vector  a0, a1, a2, a3;
+    PVG_FT_Int     i, arcs = 1;
+    PVG_FT_Error   error = 0;
+
+
+    /* number of cubic arcs to draw */
+    while (  angle_diff > PVG_FT_ARC_CUBIC_ANGLE * arcs ||
+            -angle_diff > PVG_FT_ARC_CUBIC_ANGLE * arcs )
+      arcs++;
+
+    /* control tangents */
+    coef  = PVG_FT_Tan( angle_diff / ( 4 * arcs ) );
+    coef += coef / 3;
+
+    /* compute start and first control point */
+    PVG_FT_Vector_From_Polar( &a0, radius, angle_start );
+    a1.x = PVG_FT_MulFix( -a0.y, coef );
+    a1.y = PVG_FT_MulFix(  a0.x, coef );
+
+    a0.x += center->x;
+    a0.y += center->y;
+    a1.x += a0.x;
+    a1.y += a0.y;
+
+    for ( i = 1; i <= arcs; i++ )
+    {
+      /* compute end and second control point */
+      PVG_FT_Vector_From_Polar( &a3, radius,
+                            angle_start + i * angle_diff / arcs );
+      a2.x = PVG_FT_MulFix(  a3.y, coef );
+      a2.y = PVG_FT_MulFix( -a3.x, coef );
+
+      a3.x += center->x;
+      a3.y += center->y;
+      a2.x += a3.x;
+      a2.y += a3.y;
+
+      /* add cubic arc */
+      error = ft_stroke_border_cubicto( border, &a1, &a2, &a3 );
+      if ( error )
+        break;
+
+      /* a0 = a3; */
+      a1.x = a3.x - a2.x + a3.x;
+      a1.y = a3.y - a2.y + a3.y;
+    }
+
+    return error;
+}
+
+static PVG_FT_Error ft_stroke_border_moveto(PVG_FT_StrokeBorder border,
+                                           PVG_FT_Vector*      to)
+{
+    /* close current open path if any ? */
+    if (border->start >= 0) ft_stroke_border_close(border, FALSE);
+
+    border->start = border->num_points;
+    border->movable = FALSE;
+
+    return ft_stroke_border_lineto(border, to, FALSE);
+}
+
+static void ft_stroke_border_init(PVG_FT_StrokeBorder border)
+{
+    border->points = NULL;
+    border->tags = NULL;
+
+    border->num_points = 0;
+    border->max_points = 0;
+    border->start = -1;
+    border->valid = FALSE;
+}
+
+static void ft_stroke_border_reset(PVG_FT_StrokeBorder border)
+{
+    border->num_points = 0;
+    border->start = -1;
+    border->valid = FALSE;
+}
+
+static void ft_stroke_border_done(PVG_FT_StrokeBorder border)
+{
+    free(border->points);
+    free(border->tags);
+
+    border->num_points = 0;
+    border->max_points = 0;
+    border->start = -1;
+    border->valid = FALSE;
+}
+
+static PVG_FT_Error ft_stroke_border_get_counts(PVG_FT_StrokeBorder border,
+                                               PVG_FT_UInt*        anum_points,
+                                               PVG_FT_UInt*        anum_contours)
+{
+    PVG_FT_Error error = 0;
+    PVG_FT_UInt  num_points = 0;
+    PVG_FT_UInt  num_contours = 0;
+
+    PVG_FT_UInt    count = border->num_points;
+    PVG_FT_Vector* point = border->points;
+    PVG_FT_Byte*   tags = border->tags;
+    PVG_FT_Int     in_contour = 0;
+
+    for (; count > 0; count--, num_points++, point++, tags++) {
+        if (tags[0] & PVG_FT_STROKE_TAG_BEGIN) {
+            if (in_contour != 0) goto Fail;
+
+            in_contour = 1;
+        } else if (in_contour == 0)
+            goto Fail;
+
+        if (tags[0] & PVG_FT_STROKE_TAG_END) {
+            in_contour = 0;
+            num_contours++;
+        }
+    }
+
+    if (in_contour != 0) goto Fail;
+
+    border->valid = TRUE;
+
+Exit:
+    *anum_points = num_points;
+    *anum_contours = num_contours;
+    return error;
+
+Fail:
+    num_points = 0;
+    num_contours = 0;
+    goto Exit;
+}
+
+static void ft_stroke_border_export(PVG_FT_StrokeBorder border,
+                                    PVG_FT_Outline*     outline)
+{
+    /* copy point locations */
+    if (outline->points != NULL && border->points != NULL)
+        memcpy(outline->points + outline->n_points, border->points,
+            border->num_points * sizeof(PVG_FT_Vector));
+
+    /* copy tags */
+    if (outline->tags)
+    {
+        PVG_FT_UInt  count = border->num_points;
+        PVG_FT_Byte* read = border->tags;
+        PVG_FT_Byte* write = (PVG_FT_Byte*)outline->tags + outline->n_points;
+
+        for (; count > 0; count--, read++, write++) {
+            if (*read & PVG_FT_STROKE_TAG_ON)
+                *write = PVG_FT_CURVE_TAG_ON;
+            else if (*read & PVG_FT_STROKE_TAG_CUBIC)
+                *write = PVG_FT_CURVE_TAG_CUBIC;
+            else
+                *write = PVG_FT_CURVE_TAG_CONIC;
+        }
+    }
+
+    /* copy contours */
+    if (outline->contours)
+    {
+        PVG_FT_UInt   count = border->num_points;
+        PVG_FT_Byte*  tags = border->tags;
+        PVG_FT_Int* write = outline->contours + outline->n_contours;
+        PVG_FT_Int  idx = (PVG_FT_Int)outline->n_points;
+
+        for (; count > 0; count--, tags++, idx++) {
+            if (*tags & PVG_FT_STROKE_TAG_END) {
+                *write++ = idx;
+                outline->n_contours++;
+            }
+        }
+    }
+
+    outline->n_points = (int)(outline->n_points + border->num_points);
+
+    assert(PVG_FT_Outline_Check(outline) == 0);
+}
+
+/*************************************************************************/
+/*************************************************************************/
+/*****                                                               *****/
+/*****                           STROKER                             *****/
+/*****                                                               *****/
+/*************************************************************************/
+/*************************************************************************/
+
+#define PVG_FT_SIDE_TO_ROTATE(s) (PVG_FT_ANGLE_PI2 - (s)*PVG_FT_ANGLE_PI)
+
+typedef struct PVG_FT_StrokerRec_ {
+    PVG_FT_Angle  angle_in;            /* direction into curr join */
+    PVG_FT_Angle  angle_out;           /* direction out of join  */
+    PVG_FT_Vector center;              /* current position */
+    PVG_FT_Fixed  line_length;         /* length of last lineto */
+    PVG_FT_Bool   first_point;         /* is this the start? */
+    PVG_FT_Bool   subpath_open;        /* is the subpath open? */
+    PVG_FT_Angle  subpath_angle;       /* subpath start direction */
+    PVG_FT_Vector subpath_start;       /* subpath start position */
+    PVG_FT_Fixed  subpath_line_length; /* subpath start lineto len */
+    PVG_FT_Bool   handle_wide_strokes; /* use wide strokes logic? */
+
+    PVG_FT_Stroker_LineCap  line_cap;
+    PVG_FT_Stroker_LineJoin line_join;
+    PVG_FT_Stroker_LineJoin line_join_saved;
+    PVG_FT_Fixed            miter_limit;
+    PVG_FT_Fixed            radius;
+
+    PVG_FT_StrokeBorderRec borders[2];
+} PVG_FT_StrokerRec;
+
+/* documentation is in ftstroke.h */
+
+PVG_FT_Error PVG_FT_Stroker_New(PVG_FT_Stroker* astroker)
+{
+    PVG_FT_Error   error = 0; /* assigned in PVG_FT_NEW */
+    PVG_FT_Stroker stroker = NULL;
+
+    stroker = (PVG_FT_StrokerRec*)calloc(1, sizeof(PVG_FT_StrokerRec));
+    if (stroker) {
+        ft_stroke_border_init(&stroker->borders[0]);
+        ft_stroke_border_init(&stroker->borders[1]);
+    }
+
+    *astroker = stroker;
+
+    return error;
+}
+
+void PVG_FT_Stroker_Rewind(PVG_FT_Stroker stroker)
+{
+    if (stroker) {
+        ft_stroke_border_reset(&stroker->borders[0]);
+        ft_stroke_border_reset(&stroker->borders[1]);
+    }
+}
+
+/* documentation is in ftstroke.h */
+
+void PVG_FT_Stroker_Set(PVG_FT_Stroker stroker, PVG_FT_Fixed radius,
+                       PVG_FT_Stroker_LineCap  line_cap,
+                       PVG_FT_Stroker_LineJoin line_join,
+                       PVG_FT_Fixed            miter_limit)
+{
+    stroker->radius = radius;
+    stroker->line_cap = line_cap;
+    stroker->line_join = line_join;
+    stroker->miter_limit = miter_limit;
+
+    /* ensure miter limit has sensible value */
+    if (stroker->miter_limit < 0x10000) stroker->miter_limit = 0x10000;
+
+    /* save line join style:                                           */
+    /* line join style can be temporarily changed when stroking curves */
+    stroker->line_join_saved = line_join;
+
+    PVG_FT_Stroker_Rewind(stroker);
+}
+
+/* documentation is in ftstroke.h */
+
+void PVG_FT_Stroker_Done(PVG_FT_Stroker stroker)
+{
+    if (stroker) {
+        ft_stroke_border_done(&stroker->borders[0]);
+        ft_stroke_border_done(&stroker->borders[1]);
+
+        free(stroker);
+    }
+}
+
+/* create a circular arc at a corner or cap */
+static PVG_FT_Error ft_stroker_arcto(PVG_FT_Stroker stroker, PVG_FT_Int side)
+{
+    PVG_FT_Angle        total, rotate;
+    PVG_FT_Fixed        radius = stroker->radius;
+    PVG_FT_Error        error = 0;
+    PVG_FT_StrokeBorder border = stroker->borders + side;
+
+    rotate = PVG_FT_SIDE_TO_ROTATE(side);
+
+    total = PVG_FT_Angle_Diff(stroker->angle_in, stroker->angle_out);
+    if (total == PVG_FT_ANGLE_PI) total = -rotate * 2;
+
+    error = ft_stroke_border_arcto(border, &stroker->center, radius,
+                                   stroker->angle_in + rotate, total);
+    border->movable = FALSE;
+    return error;
+}
+
+/* add a cap at the end of an opened path */
+static PVG_FT_Error
+ft_stroker_cap(PVG_FT_Stroker stroker,
+               PVG_FT_Angle angle,
+               PVG_FT_Int side)
+{
+    PVG_FT_Error error = 0;
+
+    if (stroker->line_cap == PVG_FT_STROKER_LINECAP_ROUND)
+    {
+        /* add a round cap */
+        stroker->angle_in = angle;
+        stroker->angle_out = angle + PVG_FT_ANGLE_PI;
+
+        error = ft_stroker_arcto(stroker, side);
+    }
+    else
+    {
+        /* add a square or butt cap */
+        PVG_FT_Vector        middle, delta;
+        PVG_FT_Fixed         radius = stroker->radius;
+        PVG_FT_StrokeBorder  border = stroker->borders + side;
+
+        /* compute middle point and first angle point */
+        PVG_FT_Vector_From_Polar( &middle, radius, angle );
+        delta.x = side ?  middle.y : -middle.y;
+        delta.y = side ? -middle.x :  middle.x;
+
+        if ( stroker->line_cap == PVG_FT_STROKER_LINECAP_SQUARE )
+        {
+            middle.x += stroker->center.x;
+            middle.y += stroker->center.y;
+        }
+        else  /* PVG_FT_STROKER_LINECAP_BUTT */
+        {
+            middle.x  = stroker->center.x;
+            middle.y  = stroker->center.y;
+        }
+
+        delta.x  += middle.x;
+        delta.y  += middle.y;
+
+        error = ft_stroke_border_lineto( border, &delta, FALSE );
+        if ( error )
+        goto Exit;
+
+        /* compute second angle point */
+        delta.x = middle.x - delta.x + middle.x;
+        delta.y = middle.y - delta.y + middle.y;
+
+        error = ft_stroke_border_lineto( border, &delta, FALSE );
+    }
+
+Exit:
+    return error;
+}
+
+/* process an inside corner, i.e. compute intersection */
+static PVG_FT_Error ft_stroker_inside(PVG_FT_Stroker stroker, PVG_FT_Int side,
+                                     PVG_FT_Fixed line_length)
+{
+    PVG_FT_StrokeBorder border = stroker->borders + side;
+    PVG_FT_Angle        phi, theta, rotate;
+    PVG_FT_Fixed        length;
+    PVG_FT_Vector       sigma = {0, 0};
+    PVG_FT_Vector       delta;
+    PVG_FT_Error        error = 0;
+    PVG_FT_Bool         intersect; /* use intersection of lines? */
+
+    rotate = PVG_FT_SIDE_TO_ROTATE(side);
+
+    theta = PVG_FT_Angle_Diff(stroker->angle_in, stroker->angle_out) / 2;
+
+    /* Only intersect borders if between two lineto's and both */
+    /* lines are long enough (line_length is zero for curves). */
+    if (!border->movable || line_length == 0  ||
+         theta > 0x59C000 || theta < -0x59C000 )
+        intersect = FALSE;
+    else {
+      /* compute minimum required length of lines */
+      PVG_FT_Fixed  min_length;
+
+
+      PVG_FT_Vector_Unit( &sigma, theta );
+      min_length =
+        ft_pos_abs( PVG_FT_MulDiv( stroker->radius, sigma.y, sigma.x ) );
+
+      intersect = PVG_FT_BOOL( min_length                         &&
+                           stroker->line_length >= min_length &&
+                           line_length          >= min_length );
+    }
+
+    if (!intersect) {
+        PVG_FT_Vector_From_Polar(&delta, stroker->radius,
+                                stroker->angle_out + rotate);
+        delta.x += stroker->center.x;
+        delta.y += stroker->center.y;
+
+        border->movable = FALSE;
+    } else {
+        /* compute median angle */
+        phi = stroker->angle_in + theta + rotate;
+
+      length = PVG_FT_DivFix( stroker->radius, sigma.x );
+
+      PVG_FT_Vector_From_Polar( &delta, length, phi );
+      delta.x += stroker->center.x;
+      delta.y += stroker->center.y;
+    }
+
+    error = ft_stroke_border_lineto(border, &delta, FALSE);
+
+    return error;
+}
+
+  /* process an outside corner, i.e. compute bevel/miter/round */
+static PVG_FT_Error
+ft_stroker_outside( PVG_FT_Stroker  stroker,
+                    PVG_FT_Int      side,
+                    PVG_FT_Fixed    line_length )
+{
+    PVG_FT_StrokeBorder  border = stroker->borders + side;
+    PVG_FT_Error         error;
+    PVG_FT_Angle         rotate;
+
+
+    if ( stroker->line_join == PVG_FT_STROKER_LINEJOIN_ROUND )
+      error = ft_stroker_arcto( stroker, side );
+    else
+    {
+      /* this is a mitered (pointed) or beveled (truncated) corner */
+      PVG_FT_Fixed   radius = stroker->radius;
+      PVG_FT_Vector  sigma = {0, 0};
+      PVG_FT_Angle   theta = 0, phi = 0;
+      PVG_FT_Bool    bevel, fixed_bevel;
+
+
+      rotate = PVG_FT_SIDE_TO_ROTATE( side );
+
+      bevel =
+        PVG_FT_BOOL( stroker->line_join == PVG_FT_STROKER_LINEJOIN_BEVEL );
+
+      fixed_bevel =
+        PVG_FT_BOOL( stroker->line_join != PVG_FT_STROKER_LINEJOIN_MITER_VARIABLE );
+
+      /* check miter limit first */
+      if ( !bevel )
+      {
+        theta = PVG_FT_Angle_Diff( stroker->angle_in, stroker->angle_out ) / 2;
+
+        if ( theta == PVG_FT_ANGLE_PI2 )
+          theta = -rotate;
+
+        phi    = stroker->angle_in + theta + rotate;
+
+        PVG_FT_Vector_From_Polar( &sigma, stroker->miter_limit, theta );
+
+        /* is miter limit exceeded? */
+        if ( sigma.x < 0x10000L )
+        {
+          /* don't create variable bevels for very small deviations; */
+          /* FT_Sin(x) = 0 for x <= 57                               */
+          if ( fixed_bevel || ft_pos_abs( theta ) > 57 )
+            bevel = TRUE;
+        }
+      }
+
+      if ( bevel )  /* this is a bevel (broken angle) */
+      {
+        if ( fixed_bevel )
+        {
+          /* the outer corners are simply joined together */
+          PVG_FT_Vector  delta;
+
+
+          /* add bevel */
+          PVG_FT_Vector_From_Polar( &delta,
+                                radius,
+                                stroker->angle_out + rotate );
+          delta.x += stroker->center.x;
+          delta.y += stroker->center.y;
+
+          border->movable = FALSE;
+          error = ft_stroke_border_lineto( border, &delta, FALSE );
+        }
+        else /* variable bevel or clipped miter */
+        {
+          /* the miter is truncated */
+          PVG_FT_Vector  middle, delta;
+          PVG_FT_Fixed   coef;
+
+
+          /* compute middle point and first angle point */
+          PVG_FT_Vector_From_Polar( &middle,
+                                   PVG_FT_MulFix( radius, stroker->miter_limit ),
+                                   phi );
+
+          coef    = PVG_FT_DivFix(  0x10000L - sigma.x, sigma.y );
+          delta.x = PVG_FT_MulFix(  middle.y, coef );
+          delta.y = PVG_FT_MulFix( -middle.x, coef );
+
+          middle.x += stroker->center.x;
+          middle.y += stroker->center.y;
+          delta.x  += middle.x;
+          delta.y  += middle.y;
+
+          error = ft_stroke_border_lineto( border, &delta, FALSE );
+          if ( error )
+            goto Exit;
+
+          /* compute second angle point */
+          delta.x = middle.x - delta.x + middle.x;
+          delta.y = middle.y - delta.y + middle.y;
+
+          error = ft_stroke_border_lineto( border, &delta, FALSE );
+          if ( error )
+            goto Exit;
+
+          /* finally, add an end point; only needed if not lineto */
+          /* (line_length is zero for curves)                     */
+          if ( line_length == 0 )
+          {
+            PVG_FT_Vector_From_Polar( &delta,
+                                  radius,
+                                  stroker->angle_out + rotate );
+
+            delta.x += stroker->center.x;
+            delta.y += stroker->center.y;
+
+            error = ft_stroke_border_lineto( border, &delta, FALSE );
+          }
+        }
+      }
+      else /* this is a miter (intersection) */
+      {
+        PVG_FT_Fixed   length;
+        PVG_FT_Vector  delta;
+
+
+        length = PVG_FT_MulDiv( stroker->radius, stroker->miter_limit, sigma.x );
+
+        PVG_FT_Vector_From_Polar( &delta, length, phi );
+        delta.x += stroker->center.x;
+        delta.y += stroker->center.y;
+
+        error = ft_stroke_border_lineto( border, &delta, FALSE );
+        if ( error )
+          goto Exit;
+
+        /* now add an end point; only needed if not lineto */
+        /* (line_length is zero for curves)                */
+        if ( line_length == 0 )
+        {
+          PVG_FT_Vector_From_Polar( &delta,
+                                stroker->radius,
+                                stroker->angle_out + rotate );
+          delta.x += stroker->center.x;
+          delta.y += stroker->center.y;
+
+          error = ft_stroke_border_lineto( border, &delta, FALSE );
+        }
+      }
+    }
+
+  Exit:
+    return error;
+}
+
+static PVG_FT_Error ft_stroker_process_corner(PVG_FT_Stroker stroker,
+                                             PVG_FT_Fixed   line_length)
+{
+    PVG_FT_Error error = 0;
+    PVG_FT_Angle turn;
+    PVG_FT_Int   inside_side;
+
+    turn = PVG_FT_Angle_Diff(stroker->angle_in, stroker->angle_out);
+
+    /* no specific corner processing is required if the turn is 0 */
+    if (turn == 0) goto Exit;
+
+    /* when we turn to the right, the inside side is 0 */
+    inside_side = 0;
+
+    /* otherwise, the inside side is 1 */
+    if (turn < 0) inside_side = 1;
+
+    /* process the inside side */
+    error = ft_stroker_inside(stroker, inside_side, line_length);
+    if (error) goto Exit;
+
+    /* process the outside side */
+    error = ft_stroker_outside(stroker, 1 - inside_side, line_length);
+
+Exit:
+    return error;
+}
+
+/* add two points to the left and right borders corresponding to the */
+/* start of the subpath                                              */
+static PVG_FT_Error ft_stroker_subpath_start(PVG_FT_Stroker stroker,
+                                            PVG_FT_Angle   start_angle,
+                                            PVG_FT_Fixed   line_length)
+{
+    PVG_FT_Vector       delta;
+    PVG_FT_Vector       point;
+    PVG_FT_Error        error;
+    PVG_FT_StrokeBorder border;
+
+    PVG_FT_Vector_From_Polar(&delta, stroker->radius,
+                            start_angle + PVG_FT_ANGLE_PI2);
+
+    point.x = stroker->center.x + delta.x;
+    point.y = stroker->center.y + delta.y;
+
+    border = stroker->borders;
+    error = ft_stroke_border_moveto(border, &point);
+    if (error) goto Exit;
+
+    point.x = stroker->center.x - delta.x;
+    point.y = stroker->center.y - delta.y;
+
+    border++;
+    error = ft_stroke_border_moveto(border, &point);
+
+    /* save angle, position, and line length for last join */
+    /* (line_length is zero for curves)                    */
+    stroker->subpath_angle = start_angle;
+    stroker->first_point = FALSE;
+    stroker->subpath_line_length = line_length;
+
+Exit:
+    return error;
+}
+
+/* documentation is in ftstroke.h */
+
+PVG_FT_Error PVG_FT_Stroker_LineTo(PVG_FT_Stroker stroker, PVG_FT_Vector* to)
+{
+    PVG_FT_Error        error = 0;
+    PVG_FT_StrokeBorder border;
+    PVG_FT_Vector       delta;
+    PVG_FT_Angle        angle;
+    PVG_FT_Int          side;
+    PVG_FT_Fixed        line_length;
+
+    delta.x = to->x - stroker->center.x;
+    delta.y = to->y - stroker->center.y;
+
+    /* a zero-length lineto is a no-op; avoid creating a spurious corner */
+    if (delta.x == 0 && delta.y == 0) goto Exit;
+
+    /* compute length of line */
+    line_length = PVG_FT_Vector_Length(&delta);
+
+    angle = PVG_FT_Atan2(delta.x, delta.y);
+    PVG_FT_Vector_From_Polar(&delta, stroker->radius, angle + PVG_FT_ANGLE_PI2);
+
+    /* process corner if necessary */
+    if (stroker->first_point) {
+        /* This is the first segment of a subpath.  We need to     */
+        /* add a point to each border at their respective starting */
+        /* point locations.                                        */
+        error = ft_stroker_subpath_start(stroker, angle, line_length);
+        if (error) goto Exit;
+    } else {
+        /* process the current corner */
+        stroker->angle_out = angle;
+        error = ft_stroker_process_corner(stroker, line_length);
+        if (error) goto Exit;
+    }
+
+    /* now add a line segment to both the `inside' and `outside' paths */
+    for (border = stroker->borders, side = 1; side >= 0; side--, border++) {
+        PVG_FT_Vector point;
+
+        point.x = to->x + delta.x;
+        point.y = to->y + delta.y;
+
+        /* the ends of lineto borders are movable */
+        error = ft_stroke_border_lineto(border, &point, TRUE);
+        if (error) goto Exit;
+
+        delta.x = -delta.x;
+        delta.y = -delta.y;
+    }
+
+    stroker->angle_in = angle;
+    stroker->center = *to;
+    stroker->line_length = line_length;
+
+Exit:
+    return error;
+}
+
+/* documentation is in ftstroke.h */
+
+PVG_FT_Error PVG_FT_Stroker_ConicTo(PVG_FT_Stroker stroker, PVG_FT_Vector* control,
+                                  PVG_FT_Vector* to)
+{
+    PVG_FT_Error   error = 0;
+    PVG_FT_Vector  bez_stack[34];
+    PVG_FT_Vector* arc;
+    PVG_FT_Vector* limit = bez_stack + 30;
+    PVG_FT_Bool    first_arc = TRUE;
+
+    /* if all control points are coincident, this is a no-op; */
+    /* avoid creating a spurious corner                       */
+    if (PVG_FT_IS_SMALL(stroker->center.x - control->x) &&
+        PVG_FT_IS_SMALL(stroker->center.y - control->y) &&
+        PVG_FT_IS_SMALL(control->x - to->x) &&
+        PVG_FT_IS_SMALL(control->y - to->y)) {
+        stroker->center = *to;
+        goto Exit;
+    }
+
+    arc = bez_stack;
+    arc[0] = *to;
+    arc[1] = *control;
+    arc[2] = stroker->center;
+
+    while (arc >= bez_stack) {
+        PVG_FT_Angle angle_in, angle_out;
+
+        /* initialize with current direction */
+        angle_in = angle_out = stroker->angle_in;
+
+        if (arc < limit &&
+            !ft_conic_is_small_enough(arc, &angle_in, &angle_out)) {
+            if (stroker->first_point) stroker->angle_in = angle_in;
+
+            ft_conic_split(arc);
+            arc += 2;
+            continue;
+        }
+
+        if (first_arc) {
+            first_arc = FALSE;
+
+            /* process corner if necessary */
+            if (stroker->first_point)
+                error = ft_stroker_subpath_start(stroker, angle_in, 0);
+            else {
+                stroker->angle_out = angle_in;
+                error = ft_stroker_process_corner(stroker, 0);
+            }
+        } else if (ft_pos_abs(PVG_FT_Angle_Diff(stroker->angle_in, angle_in)) >
+                   PVG_FT_SMALL_CONIC_THRESHOLD / 4) {
+            /* if the deviation from one arc to the next is too great, */
+            /* add a round corner                                      */
+            stroker->center = arc[2];
+            stroker->angle_out = angle_in;
+            stroker->line_join = PVG_FT_STROKER_LINEJOIN_ROUND;
+
+            error = ft_stroker_process_corner(stroker, 0);
+
+            /* reinstate line join style */
+            stroker->line_join = stroker->line_join_saved;
+        }
+
+        if (error) goto Exit;
+
+        /* the arc's angle is small enough; we can add it directly to each */
+        /* border                                                          */
+        {
+            PVG_FT_Vector       ctrl, end;
+            PVG_FT_Angle        theta, phi, rotate, alpha0 = 0;
+            PVG_FT_Fixed        length;
+            PVG_FT_StrokeBorder border;
+            PVG_FT_Int          side;
+
+            theta = PVG_FT_Angle_Diff(angle_in, angle_out) / 2;
+            phi = angle_in + theta;
+            length = PVG_FT_DivFix(stroker->radius, PVG_FT_Cos(theta));
+
+            /* compute direction of original arc */
+            if (stroker->handle_wide_strokes)
+                alpha0 = PVG_FT_Atan2(arc[0].x - arc[2].x, arc[0].y - arc[2].y);
+
+            for (border = stroker->borders, side = 0; side <= 1;
+                 side++, border++) {
+                rotate = PVG_FT_SIDE_TO_ROTATE(side);
+
+                /* compute control point */
+                PVG_FT_Vector_From_Polar(&ctrl, length, phi + rotate);
+                ctrl.x += arc[1].x;
+                ctrl.y += arc[1].y;
+
+                /* compute end point */
+                PVG_FT_Vector_From_Polar(&end, stroker->radius,
+                                        angle_out + rotate);
+                end.x += arc[0].x;
+                end.y += arc[0].y;
+
+                if (stroker->handle_wide_strokes) {
+                    PVG_FT_Vector start;
+                    PVG_FT_Angle  alpha1;
+
+                    /* determine whether the border radius is greater than the
+                     */
+                    /* radius of curvature of the original arc */
+                    start = border->points[border->num_points - 1];
+
+                    alpha1 = PVG_FT_Atan2(end.x - start.x, end.y - start.y);
+
+                    /* is the direction of the border arc opposite to */
+                    /* that of the original arc? */
+                    if (ft_pos_abs(PVG_FT_Angle_Diff(alpha0, alpha1)) >
+                        PVG_FT_ANGLE_PI / 2) {
+                        PVG_FT_Angle  beta, gamma;
+                        PVG_FT_Vector bvec, delta;
+                        PVG_FT_Fixed  blen, sinA, sinB, alen;
+
+                        /* use the sine rule to find the intersection point */
+                        beta =
+                            PVG_FT_Atan2(arc[2].x - start.x, arc[2].y - start.y);
+                        gamma = PVG_FT_Atan2(arc[0].x - end.x, arc[0].y - end.y);
+
+                        bvec.x = end.x - start.x;
+                        bvec.y = end.y - start.y;
+
+                        blen = PVG_FT_Vector_Length(&bvec);
+
+                        sinA = ft_pos_abs(PVG_FT_Sin(alpha1 - gamma));
+                        sinB = ft_pos_abs(PVG_FT_Sin(beta - gamma));
+
+                        alen = PVG_FT_MulDiv(blen, sinA, sinB);
+
+                        PVG_FT_Vector_From_Polar(&delta, alen, beta);
+                        delta.x += start.x;
+                        delta.y += start.y;
+
+                        /* circumnavigate the negative sector backwards */
+                        border->movable = FALSE;
+                        error = ft_stroke_border_lineto(border, &delta, FALSE);
+                        if (error) goto Exit;
+                        error = ft_stroke_border_lineto(border, &end, FALSE);
+                        if (error) goto Exit;
+                        error = ft_stroke_border_conicto(border, &ctrl, &start);
+                        if (error) goto Exit;
+                        /* and then move to the endpoint */
+                        error = ft_stroke_border_lineto(border, &end, FALSE);
+                        if (error) goto Exit;
+
+                        continue;
+                    }
+
+                    /* else fall through */
+                }
+
+                /* simply add an arc */
+                error = ft_stroke_border_conicto(border, &ctrl, &end);
+                if (error) goto Exit;
+            }
+        }
+
+        arc -= 2;
+
+        stroker->angle_in = angle_out;
+    }
+
+    stroker->center = *to;
+    stroker->line_length = 0;
+
+Exit:
+    return error;
+}
+
+/* documentation is in ftstroke.h */
+
+PVG_FT_Error PVG_FT_Stroker_CubicTo(PVG_FT_Stroker stroker, PVG_FT_Vector* control1,
+                                  PVG_FT_Vector* control2, PVG_FT_Vector* to)
+{
+    PVG_FT_Error   error = 0;
+    PVG_FT_Vector  bez_stack[37];
+    PVG_FT_Vector* arc;
+    PVG_FT_Vector* limit = bez_stack + 32;
+    PVG_FT_Bool    first_arc = TRUE;
+
+    /* if all control points are coincident, this is a no-op; */
+    /* avoid creating a spurious corner */
+    if (PVG_FT_IS_SMALL(stroker->center.x - control1->x) &&
+        PVG_FT_IS_SMALL(stroker->center.y - control1->y) &&
+        PVG_FT_IS_SMALL(control1->x - control2->x) &&
+        PVG_FT_IS_SMALL(control1->y - control2->y) &&
+        PVG_FT_IS_SMALL(control2->x - to->x) &&
+        PVG_FT_IS_SMALL(control2->y - to->y)) {
+        stroker->center = *to;
+        goto Exit;
+    }
+
+    arc = bez_stack;
+    arc[0] = *to;
+    arc[1] = *control2;
+    arc[2] = *control1;
+    arc[3] = stroker->center;
+
+    while (arc >= bez_stack) {
+        PVG_FT_Angle angle_in, angle_mid, angle_out;
+
+        /* initialize with current direction */
+        angle_in = angle_out = angle_mid = stroker->angle_in;
+
+        if (arc < limit &&
+            !ft_cubic_is_small_enough(arc, &angle_in, &angle_mid, &angle_out)) {
+            if (stroker->first_point) stroker->angle_in = angle_in;
+
+            ft_cubic_split(arc);
+            arc += 3;
+            continue;
+        }
+
+        if (first_arc) {
+            first_arc = FALSE;
+
+            /* process corner if necessary */
+            if (stroker->first_point)
+                error = ft_stroker_subpath_start(stroker, angle_in, 0);
+            else {
+                stroker->angle_out = angle_in;
+                error = ft_stroker_process_corner(stroker, 0);
+            }
+        } else if (ft_pos_abs(PVG_FT_Angle_Diff(stroker->angle_in, angle_in)) >
+                   PVG_FT_SMALL_CUBIC_THRESHOLD / 4) {
+            /* if the deviation from one arc to the next is too great, */
+            /* add a round corner                                      */
+            stroker->center = arc[3];
+            stroker->angle_out = angle_in;
+            stroker->line_join = PVG_FT_STROKER_LINEJOIN_ROUND;
+
+            error = ft_stroker_process_corner(stroker, 0);
+
+            /* reinstate line join style */
+            stroker->line_join = stroker->line_join_saved;
+        }
+
+        if (error) goto Exit;
+
+        /* the arc's angle is small enough; we can add it directly to each */
+        /* border                                                          */
+        {
+            PVG_FT_Vector       ctrl1, ctrl2, end;
+            PVG_FT_Angle        theta1, phi1, theta2, phi2, rotate, alpha0 = 0;
+            PVG_FT_Fixed        length1, length2;
+            PVG_FT_StrokeBorder border;
+            PVG_FT_Int          side;
+
+            theta1 = PVG_FT_Angle_Diff(angle_in, angle_mid) / 2;
+            theta2 = PVG_FT_Angle_Diff(angle_mid, angle_out) / 2;
+            phi1 = ft_angle_mean(angle_in, angle_mid);
+            phi2 = ft_angle_mean(angle_mid, angle_out);
+            length1 = PVG_FT_DivFix(stroker->radius, PVG_FT_Cos(theta1));
+            length2 = PVG_FT_DivFix(stroker->radius, PVG_FT_Cos(theta2));
+
+            /* compute direction of original arc */
+            if (stroker->handle_wide_strokes)
+                alpha0 = PVG_FT_Atan2(arc[0].x - arc[3].x, arc[0].y - arc[3].y);
+
+            for (border = stroker->borders, side = 0; side <= 1;
+                 side++, border++) {
+                rotate = PVG_FT_SIDE_TO_ROTATE(side);
+
+                /* compute control points */
+                PVG_FT_Vector_From_Polar(&ctrl1, length1, phi1 + rotate);
+                ctrl1.x += arc[2].x;
+                ctrl1.y += arc[2].y;
+
+                PVG_FT_Vector_From_Polar(&ctrl2, length2, phi2 + rotate);
+                ctrl2.x += arc[1].x;
+                ctrl2.y += arc[1].y;
+
+                /* compute end point */
+                PVG_FT_Vector_From_Polar(&end, stroker->radius,
+                                        angle_out + rotate);
+                end.x += arc[0].x;
+                end.y += arc[0].y;
+
+                if (stroker->handle_wide_strokes) {
+                    PVG_FT_Vector start;
+                    PVG_FT_Angle  alpha1;
+
+                    /* determine whether the border radius is greater than the
+                     */
+                    /* radius of curvature of the original arc */
+                    start = border->points[border->num_points - 1];
+
+                    alpha1 = PVG_FT_Atan2(end.x - start.x, end.y - start.y);
+
+                    /* is the direction of the border arc opposite to */
+                    /* that of the original arc? */
+                    if (ft_pos_abs(PVG_FT_Angle_Diff(alpha0, alpha1)) >
+                        PVG_FT_ANGLE_PI / 2) {
+                        PVG_FT_Angle  beta, gamma;
+                        PVG_FT_Vector bvec, delta;
+                        PVG_FT_Fixed  blen, sinA, sinB, alen;
+
+                        /* use the sine rule to find the intersection point */
+                        beta =
+                            PVG_FT_Atan2(arc[3].x - start.x, arc[3].y - start.y);
+                        gamma = PVG_FT_Atan2(arc[0].x - end.x, arc[0].y - end.y);
+
+                        bvec.x = end.x - start.x;
+                        bvec.y = end.y - start.y;
+
+                        blen = PVG_FT_Vector_Length(&bvec);
+
+                        sinA = ft_pos_abs(PVG_FT_Sin(alpha1 - gamma));
+                        sinB = ft_pos_abs(PVG_FT_Sin(beta - gamma));
+
+                        alen = PVG_FT_MulDiv(blen, sinA, sinB);
+
+                        PVG_FT_Vector_From_Polar(&delta, alen, beta);
+                        delta.x += start.x;
+                        delta.y += start.y;
+
+                        /* circumnavigate the negative sector backwards */
+                        border->movable = FALSE;
+                        error = ft_stroke_border_lineto(border, &delta, FALSE);
+                        if (error) goto Exit;
+                        error = ft_stroke_border_lineto(border, &end, FALSE);
+                        if (error) goto Exit;
+                        error = ft_stroke_border_cubicto(border, &ctrl2, &ctrl1,
+                                                         &start);
+                        if (error) goto Exit;
+                        /* and then move to the endpoint */
+                        error = ft_stroke_border_lineto(border, &end, FALSE);
+                        if (error) goto Exit;
+
+                        continue;
+                    }
+
+                    /* else fall through */
+                }
+
+                /* simply add an arc */
+                error = ft_stroke_border_cubicto(border, &ctrl1, &ctrl2, &end);
+                if (error) goto Exit;
+            }
+        }
+
+        arc -= 3;
+
+        stroker->angle_in = angle_out;
+    }
+
+    stroker->center = *to;
+    stroker->line_length = 0;
+
+Exit:
+    return error;
+}
+
+/* documentation is in ftstroke.h */
+
+PVG_FT_Error PVG_FT_Stroker_BeginSubPath(PVG_FT_Stroker stroker, PVG_FT_Vector* to,
+                                       PVG_FT_Bool open)
+{
+    /* We cannot process the first point, because there is not enough      */
+    /* information regarding its corner/cap.  The latter will be processed */
+    /* in the `PVG_FT_Stroker_EndSubPath' routine.                             */
+    /*                                                                     */
+    stroker->first_point = TRUE;
+    stroker->center = *to;
+    stroker->subpath_open = open;
+
+    /* Determine if we need to check whether the border radius is greater */
+    /* than the radius of curvature of a curve, to handle this case       */
+    /* specially.  This is only required if bevel joins or butt caps may  */
+    /* be created, because round & miter joins and round & square caps    */
+    /* cover the negative sector created with wide strokes.               */
+    stroker->handle_wide_strokes =
+        PVG_FT_BOOL(stroker->line_join != PVG_FT_STROKER_LINEJOIN_ROUND ||
+                   (stroker->subpath_open &&
+                    stroker->line_cap == PVG_FT_STROKER_LINECAP_BUTT));
+
+    /* record the subpath start point for each border */
+    stroker->subpath_start = *to;
+
+    stroker->angle_in = 0;
+
+    return 0;
+}
+
+static PVG_FT_Error ft_stroker_add_reverse_left(PVG_FT_Stroker stroker,
+                                               PVG_FT_Bool    open)
+{
+    PVG_FT_StrokeBorder right = stroker->borders + 0;
+    PVG_FT_StrokeBorder left = stroker->borders + 1;
+    PVG_FT_Int          new_points;
+    PVG_FT_Error        error = 0;
+
+    assert(left->start >= 0);
+
+    new_points = left->num_points - left->start;
+    if (new_points > 0) {
+        error = ft_stroke_border_grow(right, (PVG_FT_UInt)new_points);
+        if (error) goto Exit;
+
+        {
+            PVG_FT_Vector* dst_point = right->points + right->num_points;
+            PVG_FT_Byte*   dst_tag = right->tags + right->num_points;
+            PVG_FT_Vector* src_point = left->points + left->num_points - 1;
+            PVG_FT_Byte*   src_tag = left->tags + left->num_points - 1;
+
+            while (src_point >= left->points + left->start) {
+                *dst_point = *src_point;
+                *dst_tag = *src_tag;
+
+                if (open)
+                    dst_tag[0] &= ~PVG_FT_STROKE_TAG_BEGIN_END;
+                else {
+                    PVG_FT_Byte ttag =
+                        (PVG_FT_Byte)(dst_tag[0] & PVG_FT_STROKE_TAG_BEGIN_END);
+
+                    /* switch begin/end tags if necessary */
+                    if (ttag == PVG_FT_STROKE_TAG_BEGIN ||
+                        ttag == PVG_FT_STROKE_TAG_END)
+                        dst_tag[0] ^= PVG_FT_STROKE_TAG_BEGIN_END;
+                }
+
+                src_point--;
+                src_tag--;
+                dst_point++;
+                dst_tag++;
+            }
+        }
+
+        left->num_points = left->start;
+        right->num_points += new_points;
+
+        right->movable = FALSE;
+        left->movable = FALSE;
+    }
+
+Exit:
+    return error;
+}
+
+/* documentation is in ftstroke.h */
+
+/* there's a lot of magic in this function! */
+PVG_FT_Error PVG_FT_Stroker_EndSubPath(PVG_FT_Stroker stroker)
+{
+    PVG_FT_Error error = 0;
+
+    if (stroker->subpath_open) {
+        PVG_FT_StrokeBorder right = stroker->borders;
+
+        /* All right, this is an opened path, we need to add a cap between */
+        /* right & left, add the reverse of left, then add a final cap     */
+        /* between left & right.                                           */
+        error = ft_stroker_cap(stroker, stroker->angle_in, 0);
+        if (error) goto Exit;
+
+        /* add reversed points from `left' to `right' */
+        error = ft_stroker_add_reverse_left(stroker, TRUE);
+        if (error) goto Exit;
+
+        /* now add the final cap */
+        stroker->center = stroker->subpath_start;
+        error =
+            ft_stroker_cap(stroker, stroker->subpath_angle + PVG_FT_ANGLE_PI, 0);
+        if (error) goto Exit;
+
+        /* Now end the right subpath accordingly.  The left one is */
+        /* rewind and doesn't need further processing.             */
+        ft_stroke_border_close(right, FALSE);
+    } else {
+        PVG_FT_Angle turn;
+        PVG_FT_Int   inside_side;
+
+        /* close the path if needed */
+        if (stroker->center.x != stroker->subpath_start.x ||
+            stroker->center.y != stroker->subpath_start.y) {
+            error = PVG_FT_Stroker_LineTo(stroker, &stroker->subpath_start);
+            if (error) goto Exit;
+        }
+
+        /* process the corner */
+        stroker->angle_out = stroker->subpath_angle;
+        turn = PVG_FT_Angle_Diff(stroker->angle_in, stroker->angle_out);
+
+        /* no specific corner processing is required if the turn is 0 */
+        if (turn != 0) {
+            /* when we turn to the right, the inside side is 0 */
+            inside_side = 0;
+
+            /* otherwise, the inside side is 1 */
+            if (turn < 0) inside_side = 1;
+
+            error = ft_stroker_inside(stroker, inside_side,
+                                      stroker->subpath_line_length);
+            if (error) goto Exit;
+
+            /* process the outside side */
+            error = ft_stroker_outside(stroker, 1 - inside_side,
+                                       stroker->subpath_line_length);
+            if (error) goto Exit;
+        }
+
+        /* then end our two subpaths */
+        ft_stroke_border_close(stroker->borders + 0, FALSE);
+        ft_stroke_border_close(stroker->borders + 1, TRUE);
+    }
+
+Exit:
+    return error;
+}
+
+/* documentation is in ftstroke.h */
+
+PVG_FT_Error PVG_FT_Stroker_GetBorderCounts(PVG_FT_Stroker       stroker,
+                                          PVG_FT_StrokerBorder border,
+                                          PVG_FT_UInt*         anum_points,
+                                          PVG_FT_UInt*         anum_contours)
+{
+    PVG_FT_UInt  num_points = 0, num_contours = 0;
+    PVG_FT_Error error;
+
+    if (!stroker || border > 1) {
+        error = -1;  // PVG_FT_THROW( Invalid_Argument );
+        goto Exit;
+    }
+
+    error = ft_stroke_border_get_counts(stroker->borders + border, &num_points,
+                                        &num_contours);
+Exit:
+    if (anum_points) *anum_points = num_points;
+
+    if (anum_contours) *anum_contours = num_contours;
+
+    return error;
+}
+
+/* documentation is in ftstroke.h */
+
+PVG_FT_Error PVG_FT_Stroker_GetCounts(PVG_FT_Stroker stroker,
+                                    PVG_FT_UInt*   anum_points,
+                                    PVG_FT_UInt*   anum_contours)
+{
+    PVG_FT_UInt  count1, count2, num_points = 0;
+    PVG_FT_UInt  count3, count4, num_contours = 0;
+    PVG_FT_Error error;
+
+    error = ft_stroke_border_get_counts(stroker->borders + 0, &count1, &count2);
+    if (error) goto Exit;
+
+    error = ft_stroke_border_get_counts(stroker->borders + 1, &count3, &count4);
+    if (error) goto Exit;
+
+    num_points = count1 + count3;
+    num_contours = count2 + count4;
+
+Exit:
+    *anum_points = num_points;
+    *anum_contours = num_contours;
+    return error;
+}
+
+/* documentation is in ftstroke.h */
+
+void PVG_FT_Stroker_ExportBorder(PVG_FT_Stroker       stroker,
+                                PVG_FT_StrokerBorder border,
+                                PVG_FT_Outline*      outline)
+{
+    if (border == PVG_FT_STROKER_BORDER_LEFT ||
+        border == PVG_FT_STROKER_BORDER_RIGHT) {
+        PVG_FT_StrokeBorder sborder = &stroker->borders[border];
+
+        if (sborder->valid) ft_stroke_border_export(sborder, outline);
+    }
+}
+
+/* documentation is in ftstroke.h */
+
+void PVG_FT_Stroker_Export(PVG_FT_Stroker stroker, PVG_FT_Outline* outline)
+{
+    PVG_FT_Stroker_ExportBorder(stroker, PVG_FT_STROKER_BORDER_LEFT, outline);
+    PVG_FT_Stroker_ExportBorder(stroker, PVG_FT_STROKER_BORDER_RIGHT, outline);
+}
+
+/* documentation is in ftstroke.h */
+
+/*
+ *  The following is very similar to PVG_FT_Outline_Decompose, except
+ *  that we do support opened paths, and do not scale the outline.
+ */
+PVG_FT_Error PVG_FT_Stroker_ParseOutline(PVG_FT_Stroker        stroker,
+                                       const PVG_FT_Outline* outline)
+{
+    PVG_FT_Vector v_last;
+    PVG_FT_Vector v_control;
+    PVG_FT_Vector v_start;
+
+    PVG_FT_Vector* point;
+    PVG_FT_Vector* limit;
+    char*         tags;
+
+    PVG_FT_Error error;
+
+    PVG_FT_Int  n;     /* index of contour in outline     */
+    PVG_FT_UInt first; /* index of first point in contour */
+    PVG_FT_Int  tag;   /* current point's state           */
+
+    if (!outline || !stroker) return -1;  // PVG_FT_THROW( Invalid_Argument );
+
+    PVG_FT_Stroker_Rewind(stroker);
+
+    first = 0;
+
+    for (n = 0; n < outline->n_contours; n++) {
+        PVG_FT_UInt last; /* index of last point in contour */
+
+        last = outline->contours[n];
+        limit = outline->points + last;
+
+        /* skip empty points; we don't stroke these */
+        if (last <= first) {
+            first = last + 1;
+            continue;
+        }
+
+        v_start = outline->points[first];
+        v_last = outline->points[last];
+
+        v_control = v_start;
+
+        point = outline->points + first;
+        tags = outline->tags + first;
+        tag = PVG_FT_CURVE_TAG(tags[0]);
+
+        /* A contour cannot start with a cubic control point! */
+        if (tag == PVG_FT_CURVE_TAG_CUBIC) goto Invalid_Outline;
+
+        /* check first point to determine origin */
+        if (tag == PVG_FT_CURVE_TAG_CONIC) {
+            /* First point is conic control.  Yes, this happens. */
+            if (PVG_FT_CURVE_TAG(outline->tags[last]) == PVG_FT_CURVE_TAG_ON) {
+                /* start at last point if it is on the curve */
+                v_start = v_last;
+                limit--;
+            } else {
+                /* if both first and last points are conic, */
+                /* start at their middle                    */
+                v_start.x = (v_start.x + v_last.x) / 2;
+                v_start.y = (v_start.y + v_last.y) / 2;
+            }
+            point--;
+            tags--;
+        }
+
+        error = PVG_FT_Stroker_BeginSubPath(stroker, &v_start, outline->contours_flag[n]);
+        if (error) goto Exit;
+
+        while (point < limit) {
+            point++;
+            tags++;
+
+            tag = PVG_FT_CURVE_TAG(tags[0]);
+            switch (tag) {
+            case PVG_FT_CURVE_TAG_ON: /* emit a single line_to */
+            {
+                PVG_FT_Vector vec;
+
+                vec.x = point->x;
+                vec.y = point->y;
+
+                error = PVG_FT_Stroker_LineTo(stroker, &vec);
+                if (error) goto Exit;
+                continue;
+            }
+
+            case PVG_FT_CURVE_TAG_CONIC: /* consume conic arcs */
+                v_control.x = point->x;
+                v_control.y = point->y;
+
+            Do_Conic:
+                if (point < limit) {
+                    PVG_FT_Vector vec;
+                    PVG_FT_Vector v_middle;
+
+                    point++;
+                    tags++;
+                    tag = PVG_FT_CURVE_TAG(tags[0]);
+
+                    vec = point[0];
+
+                    if (tag == PVG_FT_CURVE_TAG_ON) {
+                        error =
+                            PVG_FT_Stroker_ConicTo(stroker, &v_control, &vec);
+                        if (error) goto Exit;
+                        continue;
+                    }
+
+                    if (tag != PVG_FT_CURVE_TAG_CONIC) goto Invalid_Outline;
+
+                    v_middle.x = (v_control.x + vec.x) / 2;
+                    v_middle.y = (v_control.y + vec.y) / 2;
+
+                    error =
+                        PVG_FT_Stroker_ConicTo(stroker, &v_control, &v_middle);
+                    if (error) goto Exit;
+
+                    v_control = vec;
+                    goto Do_Conic;
+                }
+
+                error = PVG_FT_Stroker_ConicTo(stroker, &v_control, &v_start);
+                goto Close;
+
+            default: /* PVG_FT_CURVE_TAG_CUBIC */
+            {
+                PVG_FT_Vector vec1, vec2;
+
+                if (point + 1 > limit ||
+                    PVG_FT_CURVE_TAG(tags[1]) != PVG_FT_CURVE_TAG_CUBIC)
+                    goto Invalid_Outline;
+
+                point += 2;
+                tags += 2;
+
+                vec1 = point[-2];
+                vec2 = point[-1];
+
+                if (point <= limit) {
+                    PVG_FT_Vector vec;
+
+                    vec = point[0];
+
+                    error = PVG_FT_Stroker_CubicTo(stroker, &vec1, &vec2, &vec);
+                    if (error) goto Exit;
+                    continue;
+                }
+
+                error = PVG_FT_Stroker_CubicTo(stroker, &vec1, &vec2, &v_start);
+                goto Close;
+            }
+            }
+        }
+
+    Close:
+        if (error) goto Exit;
+
+        if (stroker->first_point) {
+            stroker->subpath_open = TRUE;
+            error = ft_stroker_subpath_start(stroker, 0, 0);
+            if (error) goto Exit;
+        }
+
+        error = PVG_FT_Stroker_EndSubPath(stroker);
+        if (error) goto Exit;
+
+        first = last + 1;
+    }
+
+    return 0;
+
+Exit:
+    return error;
+
+Invalid_Outline:
+    return -2;  // PVG_FT_THROW( Invalid_Outline );
+}
+
+/* END */

--- a/source/plutovg/plutovg-ft-stroker.h
+++ b/source/plutovg/plutovg-ft-stroker.h
@@ -1,0 +1,320 @@
+/***************************************************************************/
+/*                                                                         */
+/*  ftstroke.h                                                             */
+/*                                                                         */
+/*    FreeType path stroker (specification).                               */
+/*                                                                         */
+/*  Copyright 2002-2006, 2008, 2009, 2011-2012 by                          */
+/*  David Turner, Robert Wilhelm, and Werner Lemberg.                      */
+/*                                                                         */
+/*  This file is part of the FreeType project, and may only be used,       */
+/*  modified, and distributed under the terms of the FreeType project      */
+/*  license, LICENSE.TXT.  By continuing to use, modify, or distribute     */
+/*  this file you indicate that you have read the license and              */
+/*  understand and accept it fully.                                        */
+/*                                                                         */
+/***************************************************************************/
+
+#ifndef PLUTOVG_FT_STROKER_H
+#define PLUTOVG_FT_STROKER_H
+
+#include "plutovg-ft-raster.h"
+
+/**************************************************************
+ *
+ * @type:
+ *   PVG_FT_Stroker
+ *
+ * @description:
+ *   Opaque handler to a path stroker object.
+ */
+typedef struct PVG_FT_StrokerRec_*  PVG_FT_Stroker;
+
+
+/**************************************************************
+ *
+ * @enum:
+ *   PVG_FT_Stroker_LineJoin
+ *
+ * @description:
+ *   These values determine how two joining lines are rendered
+ *   in a stroker.
+ *
+ * @values:
+ *   PVG_FT_STROKER_LINEJOIN_ROUND ::
+ *     Used to render rounded line joins.  Circular arcs are used
+ *     to join two lines smoothly.
+ *
+ *   PVG_FT_STROKER_LINEJOIN_BEVEL ::
+ *     Used to render beveled line joins.  The outer corner of
+ *     the joined lines is filled by enclosing the triangular
+ *     region of the corner with a straight line between the
+ *     outer corners of each stroke.
+ *
+ *   PVG_FT_STROKER_LINEJOIN_MITER_FIXED ::
+ *     Used to render mitered line joins, with fixed bevels if the
+ *     miter limit is exceeded.  The outer edges of the strokes
+ *     for the two segments are extended until they meet at an
+ *     angle.  If the segments meet at too sharp an angle (such
+ *     that the miter would extend from the intersection of the
+ *     segments a distance greater than the product of the miter
+ *     limit value and the border radius), then a bevel join (see
+ *     above) is used instead.  This prevents long spikes being
+ *     created.  PVG_FT_STROKER_LINEJOIN_MITER_FIXED generates a miter
+ *     line join as used in PostScript and PDF.
+ *
+ *   PVG_FT_STROKER_LINEJOIN_MITER_VARIABLE ::
+ *   PVG_FT_STROKER_LINEJOIN_MITER ::
+ *     Used to render mitered line joins, with variable bevels if
+ *     the miter limit is exceeded.  The intersection of the
+ *     strokes is clipped at a line perpendicular to the bisector
+ *     of the angle between the strokes, at the distance from the
+ *     intersection of the segments equal to the product of the
+ *     miter limit value and the border radius.  This prevents
+ *     long spikes being created.
+ *     PVG_FT_STROKER_LINEJOIN_MITER_VARIABLE generates a mitered line
+ *     join as used in XPS.  PVG_FT_STROKER_LINEJOIN_MITER is an alias
+ *     for PVG_FT_STROKER_LINEJOIN_MITER_VARIABLE, retained for
+ *     backwards compatibility.
+ */
+typedef enum  PVG_FT_Stroker_LineJoin_
+{
+    PVG_FT_STROKER_LINEJOIN_ROUND          = 0,
+    PVG_FT_STROKER_LINEJOIN_BEVEL          = 1,
+    PVG_FT_STROKER_LINEJOIN_MITER_VARIABLE = 2,
+    PVG_FT_STROKER_LINEJOIN_MITER          = PVG_FT_STROKER_LINEJOIN_MITER_VARIABLE,
+    PVG_FT_STROKER_LINEJOIN_MITER_FIXED    = 3
+
+} PVG_FT_Stroker_LineJoin;
+
+
+/**************************************************************
+ *
+ * @enum:
+ *   PVG_FT_Stroker_LineCap
+ *
+ * @description:
+ *   These values determine how the end of opened sub-paths are
+ *   rendered in a stroke.
+ *
+ * @values:
+ *   PVG_FT_STROKER_LINECAP_BUTT ::
+ *     The end of lines is rendered as a full stop on the last
+ *     point itself.
+ *
+ *   PVG_FT_STROKER_LINECAP_ROUND ::
+ *     The end of lines is rendered as a half-circle around the
+ *     last point.
+ *
+ *   PVG_FT_STROKER_LINECAP_SQUARE ::
+ *     The end of lines is rendered as a square around the
+ *     last point.
+ */
+typedef enum  PVG_FT_Stroker_LineCap_
+{
+    PVG_FT_STROKER_LINECAP_BUTT = 0,
+    PVG_FT_STROKER_LINECAP_ROUND,
+    PVG_FT_STROKER_LINECAP_SQUARE
+
+} PVG_FT_Stroker_LineCap;
+
+
+/**************************************************************
+ *
+ * @enum:
+ *   PVG_FT_StrokerBorder
+ *
+ * @description:
+ *   These values are used to select a given stroke border
+ *   in @PVG_FT_Stroker_GetBorderCounts and @PVG_FT_Stroker_ExportBorder.
+ *
+ * @values:
+ *   PVG_FT_STROKER_BORDER_LEFT ::
+ *     Select the left border, relative to the drawing direction.
+ *
+ *   PVG_FT_STROKER_BORDER_RIGHT ::
+ *     Select the right border, relative to the drawing direction.
+ *
+ * @note:
+ *   Applications are generally interested in the `inside' and `outside'
+ *   borders.  However, there is no direct mapping between these and the
+ *   `left' and `right' ones, since this really depends on the glyph's
+ *   drawing orientation, which varies between font formats.
+ *
+ *   You can however use @PVG_FT_Outline_GetInsideBorder and
+ *   @PVG_FT_Outline_GetOutsideBorder to get these.
+ */
+typedef enum  PVG_FT_StrokerBorder_
+{
+    PVG_FT_STROKER_BORDER_LEFT = 0,
+    PVG_FT_STROKER_BORDER_RIGHT
+
+} PVG_FT_StrokerBorder;
+
+
+/**************************************************************
+ *
+ * @function:
+ *   PVG_FT_Stroker_New
+ *
+ * @description:
+ *   Create a new stroker object.
+ *
+ * @input:
+ *   library ::
+ *     FreeType library handle.
+ *
+ * @output:
+ *   astroker ::
+ *     A new stroker object handle.  NULL in case of error.
+ *
+ * @return:
+ *    FreeType error code.  0~means success.
+ */
+PVG_FT_Error
+PVG_FT_Stroker_New( PVG_FT_Stroker  *astroker );
+
+
+/**************************************************************
+ *
+ * @function:
+ *   PVG_FT_Stroker_Set
+ *
+ * @description:
+ *   Reset a stroker object's attributes.
+ *
+ * @input:
+ *   stroker ::
+ *     The target stroker handle.
+ *
+ *   radius ::
+ *     The border radius.
+ *
+ *   line_cap ::
+ *     The line cap style.
+ *
+ *   line_join ::
+ *     The line join style.
+ *
+ *   miter_limit ::
+ *     The miter limit for the PVG_FT_STROKER_LINEJOIN_MITER_FIXED and
+ *     PVG_FT_STROKER_LINEJOIN_MITER_VARIABLE line join styles,
+ *     expressed as 16.16 fixed-point value.
+ *
+ * @note:
+ *   The radius is expressed in the same units as the outline
+ *   coordinates.
+ */
+void
+PVG_FT_Stroker_Set( PVG_FT_Stroker           stroker,
+    PVG_FT_Fixed             radius,
+    PVG_FT_Stroker_LineCap   line_cap,
+    PVG_FT_Stroker_LineJoin  line_join,
+    PVG_FT_Fixed             miter_limit );
+
+/**************************************************************
+ *
+ * @function:
+ *   PVG_FT_Stroker_ParseOutline
+ *
+ * @description:
+ *   A convenience function used to parse a whole outline with
+ *   the stroker.  The resulting outline(s) can be retrieved
+ *   later by functions like @PVG_FT_Stroker_GetCounts and @PVG_FT_Stroker_Export.
+ *
+ * @input:
+ *   stroker ::
+ *     The target stroker handle.
+ *
+ *   outline ::
+ *     The source outline.
+ *
+ *
+ * @return:
+ *   FreeType error code.  0~means success.
+ *
+ * @note:
+ *   If `opened' is~0 (the default), the outline is treated as a closed
+ *   path, and the stroker generates two distinct `border' outlines.
+ *
+ *
+ *   This function calls @PVG_FT_Stroker_Rewind automatically.
+ */
+PVG_FT_Error
+PVG_FT_Stroker_ParseOutline( PVG_FT_Stroker   stroker,
+    const PVG_FT_Outline*  outline);
+
+
+/**************************************************************
+ *
+ * @function:
+ *   PVG_FT_Stroker_GetCounts
+ *
+ * @description:
+ *   Call this function once you have finished parsing your paths
+ *   with the stroker.  It returns the number of points and
+ *   contours necessary to export all points/borders from the stroked
+ *   outline/path.
+ *
+ * @input:
+ *   stroker ::
+ *     The target stroker handle.
+ *
+ * @output:
+ *   anum_points ::
+ *     The number of points.
+ *
+ *   anum_contours ::
+ *     The number of contours.
+ *
+ * @return:
+ *   FreeType error code.  0~means success.
+ */
+PVG_FT_Error
+PVG_FT_Stroker_GetCounts( PVG_FT_Stroker  stroker,
+    PVG_FT_UInt    *anum_points,
+    PVG_FT_UInt    *anum_contours );
+
+
+/**************************************************************
+ *
+ * @function:
+ *   PVG_FT_Stroker_Export
+ *
+ * @description:
+ *   Call this function after @PVG_FT_Stroker_GetBorderCounts to
+ *   export all borders to your own @PVG_FT_Outline structure.
+ *
+ *   Note that this function appends the border points and
+ *   contours to your outline, but does not try to resize its
+ *   arrays.
+ *
+ * @input:
+ *   stroker ::
+ *     The target stroker handle.
+ *
+ *   outline ::
+ *     The target outline handle.
+ */
+void
+PVG_FT_Stroker_Export( PVG_FT_Stroker   stroker,
+    PVG_FT_Outline*  outline );
+
+
+/**************************************************************
+ *
+ * @function:
+ *   PVG_FT_Stroker_Done
+ *
+ * @description:
+ *   Destroy a stroker object.
+ *
+ * @input:
+ *   stroker ::
+ *     A stroker handle.  Can be NULL.
+ */
+void
+PVG_FT_Stroker_Done( PVG_FT_Stroker  stroker );
+
+
+#endif // PLUTOVG_FT_STROKER_H

--- a/source/plutovg/plutovg-ft-types.h
+++ b/source/plutovg/plutovg-ft-types.h
@@ -1,0 +1,173 @@
+/****************************************************************************
+ *
+ * fttypes.h
+ *
+ *   FreeType simple types definitions (specification only).
+ *
+ * Copyright (C) 1996-2020 by
+ * David Turner, Robert Wilhelm, and Werner Lemberg.
+ *
+ * This file is part of the FreeType project, and may only be used,
+ * modified, and distributed under the terms of the FreeType project
+ * license, LICENSE.TXT.  By continuing to use, modify, or distribute
+ * this file you indicate that you have read the license and
+ * understand and accept it fully.
+ *
+ */
+
+#ifndef PLUTOVG_FT_TYPES_H
+#define PLUTOVG_FT_TYPES_H
+
+/*************************************************************************/
+/*                                                                       */
+/* <Type>                                                                */
+/*    PVG_FT_Fixed                                                           */
+/*                                                                       */
+/* <Description>                                                         */
+/*    This type is used to store 16.16 fixed-point values, like scaling  */
+/*    values or matrix coefficients.                                     */
+/*                                                                       */
+typedef signed long  PVG_FT_Fixed;
+
+
+/*************************************************************************/
+/*                                                                       */
+/* <Type>                                                                */
+/*    PVG_FT_Int                                                             */
+/*                                                                       */
+/* <Description>                                                         */
+/*    A typedef for the int type.                                        */
+/*                                                                       */
+typedef signed int  PVG_FT_Int;
+
+
+/*************************************************************************/
+/*                                                                       */
+/* <Type>                                                                */
+/*    PVG_FT_UInt                                                            */
+/*                                                                       */
+/* <Description>                                                         */
+/*    A typedef for the unsigned int type.                               */
+/*                                                                       */
+typedef unsigned int  PVG_FT_UInt;
+
+
+/*************************************************************************/
+/*                                                                       */
+/* <Type>                                                                */
+/*    PVG_FT_Long                                                            */
+/*                                                                       */
+/* <Description>                                                         */
+/*    A typedef for signed long.                                         */
+/*                                                                       */
+typedef signed long  PVG_FT_Long;
+
+
+/*************************************************************************/
+/*                                                                       */
+/* <Type>                                                                */
+/*    PVG_FT_ULong                                                           */
+/*                                                                       */
+/* <Description>                                                         */
+/*    A typedef for unsigned long.                                       */
+/*                                                                       */
+typedef unsigned long PVG_FT_ULong;
+
+/*************************************************************************/
+/*                                                                       */
+/* <Type>                                                                */
+/*    PVG_FT_Short                                                           */
+/*                                                                       */
+/* <Description>                                                         */
+/*    A typedef for signed short.                                        */
+/*                                                                       */
+typedef signed short  PVG_FT_Short;
+
+
+/*************************************************************************/
+/*                                                                       */
+/* <Type>                                                                */
+/*    PVG_FT_Byte                                                            */
+/*                                                                       */
+/* <Description>                                                         */
+/*    A simple typedef for the _unsigned_ char type.                     */
+/*                                                                       */
+typedef unsigned char  PVG_FT_Byte;
+
+
+/*************************************************************************/
+/*                                                                       */
+/* <Type>                                                                */
+/*    PVG_FT_Bool                                                            */
+/*                                                                       */
+/* <Description>                                                         */
+/*    A typedef of unsigned char, used for simple booleans.  As usual,   */
+/*    values 1 and~0 represent true and false, respectively.             */
+/*                                                                       */
+typedef unsigned char  PVG_FT_Bool;
+
+
+
+/*************************************************************************/
+/*                                                                       */
+/* <Type>                                                                */
+/*    PVG_FT_Error                                                           */
+/*                                                                       */
+/* <Description>                                                         */
+/*    The FreeType error code type.  A value of~0 is always interpreted  */
+/*    as a successful operation.                                         */
+/*                                                                       */
+typedef int  PVG_FT_Error;
+
+
+/*************************************************************************/
+/*                                                                       */
+/* <Type>                                                                */
+/*    PVG_FT_Pos                                                             */
+/*                                                                       */
+/* <Description>                                                         */
+/*    The type PVG_FT_Pos is used to store vectorial coordinates.  Depending */
+/*    on the context, these can represent distances in integer font      */
+/*    units, or 16.16, or 26.6 fixed-point pixel coordinates.            */
+/*                                                                       */
+typedef signed long  PVG_FT_Pos;
+
+
+/*************************************************************************/
+/*                                                                       */
+/* <Struct>                                                              */
+/*    PVG_FT_Vector                                                          */
+/*                                                                       */
+/* <Description>                                                         */
+/*    A simple structure used to store a 2D vector; coordinates are of   */
+/*    the PVG_FT_Pos type.                                                   */
+/*                                                                       */
+/* <Fields>                                                              */
+/*    x :: The horizontal coordinate.                                    */
+/*    y :: The vertical coordinate.                                      */
+/*                                                                       */
+typedef struct  PVG_FT_Vector_
+{
+    PVG_FT_Pos  x;
+    PVG_FT_Pos  y;
+
+} PVG_FT_Vector;
+
+
+typedef long long int           PVG_FT_Int64;
+typedef unsigned long long int  PVG_FT_UInt64;
+
+typedef signed int              PVG_FT_Int32;
+typedef unsigned int            PVG_FT_UInt32;
+
+#define PVG_FT_BOOL( x )  ( (PVG_FT_Bool)( x ) )
+
+#ifndef TRUE
+#define TRUE  1
+#endif
+
+#ifndef FALSE
+#define FALSE  0
+#endif
+
+#endif // PLUTOVG_FT_TYPES_H

--- a/source/plutovg/plutovg-geometry.cpp
+++ b/source/plutovg/plutovg-geometry.cpp
@@ -1,0 +1,542 @@
+#include "plutovg-private.h"
+
+#include <math.h>
+
+void plutovg_rect_init(plutovg_rect_t* rect, double x, double y, double w, double h)
+{
+    rect->x = x;
+    rect->y = y;
+    rect->w = w;
+    rect->h = h;
+}
+
+void plutovg_rect_init_zero(plutovg_rect_t* rect)
+{
+    rect->x = 0.0;
+    rect->y = 0.0;
+    rect->w = 0.0;
+    rect->h = 0.0;
+}
+
+void plutovg_matrix_init(plutovg_matrix_t* matrix, double m00, double m10, double m01, double m11, double m02, double m12)
+{
+    matrix->m00 = m00;
+    matrix->m10 = m10;
+    matrix->m01 = m01;
+    matrix->m11 = m11;
+    matrix->m02 = m02;
+    matrix->m12 = m12;
+}
+
+void plutovg_matrix_init_identity(plutovg_matrix_t* matrix)
+{
+    matrix->m00 = 1.0;
+    matrix->m10 = 0.0;
+    matrix->m01 = 0.0;
+    matrix->m11 = 1.0;
+    matrix->m02 = 0.0;
+    matrix->m12 = 0.0;
+}
+
+void plutovg_matrix_init_translate(plutovg_matrix_t* matrix, double x, double y)
+{
+    plutovg_matrix_init(matrix, 1.0, 0.0, 0.0, 1.0, x, y);
+}
+
+void plutovg_matrix_init_scale(plutovg_matrix_t* matrix, double x, double y)
+{
+    plutovg_matrix_init(matrix, x, 0.0, 0.0, y, 0.0, 0.0);
+}
+
+void plutovg_matrix_init_shear(plutovg_matrix_t* matrix, double x, double y)
+{
+    plutovg_matrix_init(matrix, 1.0, tan(y), tan(x), 1.0, 0.0, 0.0);
+}
+
+void plutovg_matrix_init_rotate(plutovg_matrix_t* matrix, double radians, double x, double y)
+{
+    double c = cos(radians);
+    double s = sin(radians);
+
+    double cx = x * (1 - c) + y * s;
+    double cy = y * (1 - c) - x * s;
+
+    plutovg_matrix_init(matrix, c, s, -s, c, cx, cy);
+}
+
+void plutovg_matrix_translate(plutovg_matrix_t* matrix, double x, double y)
+{
+    plutovg_matrix_t m;
+    plutovg_matrix_init_translate(&m, x, y);
+    plutovg_matrix_multiply(matrix, &m, matrix);
+}
+
+void plutovg_matrix_scale(plutovg_matrix_t* matrix, double x, double y)
+{
+    plutovg_matrix_t m;
+    plutovg_matrix_init_scale(&m, x, y);
+    plutovg_matrix_multiply(matrix, &m, matrix);
+}
+
+void plutovg_matrix_shear(plutovg_matrix_t* matrix, double x, double y)
+{
+    plutovg_matrix_t m;
+    plutovg_matrix_init_shear(&m, x, y);
+    plutovg_matrix_multiply(matrix, &m, matrix);
+}
+
+void plutovg_matrix_rotate(plutovg_matrix_t* matrix, double radians, double x, double y)
+{
+    plutovg_matrix_t m;
+    plutovg_matrix_init_rotate(&m, radians, x, y);
+    plutovg_matrix_multiply(matrix, &m, matrix);
+}
+
+void plutovg_matrix_multiply(plutovg_matrix_t* matrix, const plutovg_matrix_t* a, const plutovg_matrix_t* b)
+{
+    double m00 = a->m00 * b->m00 + a->m10 * b->m01;
+    double m10 = a->m00 * b->m10 + a->m10 * b->m11;
+    double m01 = a->m01 * b->m00 + a->m11 * b->m01;
+    double m11 = a->m01 * b->m10 + a->m11 * b->m11;
+    double m02 = a->m02 * b->m00 + a->m12 * b->m01 + b->m02;
+    double m12 = a->m02 * b->m10 + a->m12 * b->m11 + b->m12;
+
+    plutovg_matrix_init(matrix, m00, m10, m01, m11, m02, m12);
+}
+
+int plutovg_matrix_invert(plutovg_matrix_t* matrix)
+{
+    double det = (matrix->m00 * matrix->m11 - matrix->m10 * matrix->m01);
+    if (det == 0.0)
+        return 0;
+
+    double inv_det = 1.0 / det;
+    double m00 = matrix->m00 * inv_det;
+    double m10 = matrix->m10 * inv_det;
+    double m01 = matrix->m01 * inv_det;
+    double m11 = matrix->m11 * inv_det;
+    double m02 = (matrix->m01 * matrix->m12 - matrix->m11 * matrix->m02) * inv_det;
+    double m12 = (matrix->m10 * matrix->m02 - matrix->m00 * matrix->m12) * inv_det;
+
+    plutovg_matrix_init(matrix, m11, -m10, -m01, m00, m02, m12);
+    return 1;
+}
+
+void plutovg_matrix_map(const plutovg_matrix_t* matrix, double x, double y, double* _x, double* _y)
+{
+    *_x = x * matrix->m00 + y * matrix->m01 + matrix->m02;
+    *_y = x * matrix->m10 + y * matrix->m11 + matrix->m12;
+}
+
+void plutovg_matrix_map_point(const plutovg_matrix_t* matrix, const plutovg_point_t* src, plutovg_point_t* dst)
+{
+    plutovg_matrix_map(matrix, src->x, src->y, &dst->x, &dst->y);
+}
+
+void plutovg_matrix_map_rect(const plutovg_matrix_t* matrix, const plutovg_rect_t* src, plutovg_rect_t* dst)
+{
+    plutovg_point_t p[4];
+    p[0].x = src->x;
+    p[0].y = src->y;
+    p[1].x = src->x + src->w;
+    p[1].y = src->y;
+    p[2].x = src->x + src->w;
+    p[2].y = src->y + src->h;
+    p[3].x = src->x;
+    p[3].y = src->y + src->h;
+
+    plutovg_matrix_map_point(matrix, &p[0], &p[0]);
+    plutovg_matrix_map_point(matrix, &p[1], &p[1]);
+    plutovg_matrix_map_point(matrix, &p[2], &p[2]);
+    plutovg_matrix_map_point(matrix, &p[3], &p[3]);
+
+    double l = p[0].x;
+    double t = p[0].y;
+    double r = p[0].x;
+    double b = p[0].y;
+
+    for (int i = 0; i < 4; i++)
+    {
+        if (p[i].x < l)
+            l = p[i].x;
+        if (p[i].x > r)
+            r = p[i].x;
+        if (p[i].y < t)
+            t = p[i].y;
+        if (p[i].y > b)
+            b = p[i].y;
+    }
+
+    dst->x = l;
+    dst->y = t;
+    dst->w = r - l;
+    dst->h = b - t;
+}
+
+plutovg_path_t* plutovg_path_create(void)
+{
+    return new plutovg_path;
+}
+
+plutovg_path_t* plutovg_path_reference(plutovg_path_t* path)
+{
+    ++path->ref;
+    return path;
+}
+
+void plutovg_path_destroy(plutovg_path_t* path)
+{
+    if (path == nullptr)
+        return;
+
+    if (--path->ref == 0)
+    {
+        delete path;
+    }
+}
+
+int plutovg_path_get_reference_count(const plutovg_path_t* path)
+{
+    return path->ref;
+}
+
+void plutovg_path_move_to(plutovg_path_t* path, double x, double y)
+{
+    path->elements.emplace_back(plutovg_path_element_move_to);
+    path->points.emplace_back(plutovg_point_t { x, y });
+
+    path->contours += 1;
+
+    path->start.x = x;
+    path->start.y = y;
+}
+
+void plutovg_path_line_to(plutovg_path_t* path, double x, double y)
+{
+    path->elements.emplace_back(plutovg_path_element_line_to);
+    path->points.emplace_back(plutovg_point_t { x, y });
+}
+
+void plutovg_path_quad_to(plutovg_path_t* path, double x1, double y1, double x2, double y2)
+{
+    double x, y;
+    plutovg_path_get_current_point(path, &x, &y);
+
+    double cx = 2.0 / 3.0 * x1 + 1.0 / 3.0 * x;
+    double cy = 2.0 / 3.0 * y1 + 1.0 / 3.0 * y;
+    double cx1 = 2.0 / 3.0 * x1 + 1.0 / 3.0 * x2;
+    double cy1 = 2.0 / 3.0 * y1 + 1.0 / 3.0 * y2;
+    plutovg_path_cubic_to(path, cx, cy, cx1, cy1, x2, y2);
+}
+
+void plutovg_path_cubic_to(plutovg_path_t* path, double x1, double y1, double x2, double y2, double x3, double y3)
+{
+    path->elements.emplace_back(plutovg_path_element_cubic_to);
+    path->points.emplace_back(plutovg_point_t { x1, y1 });
+    path->points.emplace_back(plutovg_point_t { x2, y2 });
+    path->points.emplace_back(plutovg_point_t { x3, y3 });
+}
+
+void plutovg_path_close(plutovg_path_t* path)
+{
+    if (path->elements.empty())
+        return;
+
+    if (path->elements.back() == plutovg_path_element_close)
+        return;
+
+    path->elements.emplace_back(plutovg_path_element_close);
+    path->points.emplace_back(plutovg_point_t { path->start.x, path->start.y });
+}
+
+static inline void rel_to_abs(const plutovg_path_t* path, double* x, double* y)
+{
+    double _x, _y;
+    plutovg_path_get_current_point(path, &_x, &_y);
+
+    *x += _x;
+    *y += _y;
+}
+
+void plutovg_path_rel_move_to(plutovg_path_t* path, double x, double y)
+{
+    rel_to_abs(path, &x, &y);
+    plutovg_path_move_to(path, x, y);
+}
+
+void plutovg_path_rel_line_to(plutovg_path_t* path, double x, double y)
+{
+    rel_to_abs(path, &x, &y);
+    plutovg_path_line_to(path, x, y);
+}
+
+void plutovg_path_rel_quad_to(plutovg_path_t* path, double x1, double y1, double x2, double y2)
+{
+    rel_to_abs(path, &x1, &y1);
+    rel_to_abs(path, &x2, &y2);
+    plutovg_path_quad_to(path, x1, y1, x2, y2);
+}
+
+void plutovg_path_rel_cubic_to(plutovg_path_t* path, double x1, double y1, double x2, double y2, double x3, double y3)
+{
+    rel_to_abs(path, &x1, &y1);
+    rel_to_abs(path, &x2, &y2);
+    rel_to_abs(path, &x3, &y3);
+    plutovg_path_cubic_to(path, x1, y1, x2, y2, x3, y3);
+}
+
+void plutovg_path_add_rect(plutovg_path_t* path, double x, double y, double w, double h)
+{
+    plutovg_path_move_to(path, x, y);
+    plutovg_path_line_to(path, x + w, y);
+    plutovg_path_line_to(path, x + w, y + h);
+    plutovg_path_line_to(path, x, y + h);
+    plutovg_path_line_to(path, x, y);
+    plutovg_path_close(path);
+}
+
+void plutovg_path_add_round_rect(plutovg_path_t* path, double x, double y, double w, double h, double rx, double ry)
+{
+    double right = x + w;
+    double bottom = y + h;
+
+    double cpx = rx * plutovg_kappa;
+    double cpy = ry * plutovg_kappa;
+
+    plutovg_path_move_to(path, x, y + ry);
+    plutovg_path_cubic_to(path, x, y + ry - cpy, x + rx - cpx, y, x + rx, y);
+    plutovg_path_line_to(path, right - rx, y);
+    plutovg_path_cubic_to(path, right - rx + cpx, y, right, y + ry - cpy, right, y + ry);
+    plutovg_path_line_to(path, right, bottom - ry);
+    plutovg_path_cubic_to(path, right, bottom - ry + cpy, right - rx + cpx, bottom, right - rx, bottom);
+    plutovg_path_line_to(path, x + rx, bottom);
+    plutovg_path_cubic_to(path, x + rx - cpx, bottom, x, bottom - ry + cpy, x, bottom - ry);
+    plutovg_path_line_to(path, x, y + ry);
+    plutovg_path_close(path);
+}
+
+void plutovg_path_add_ellipse(plutovg_path_t* path, double cx, double cy, double rx, double ry)
+{
+    double left = cx - rx;
+    double top = cy - ry;
+    double right = cx + rx;
+    double bottom = cy + ry;
+
+    double cpx = rx * plutovg_kappa;
+    double cpy = ry * plutovg_kappa;
+
+    plutovg_path_move_to(path, cx, top);
+    plutovg_path_cubic_to(path, cx + cpx, top, right, cy - cpy, right, cy);
+    plutovg_path_cubic_to(path, right, cy + cpy, cx + cpx, bottom, cx, bottom);
+    plutovg_path_cubic_to(path, cx - cpx, bottom, left, cy + cpy, left, cy);
+    plutovg_path_cubic_to(path, left, cy - cpy, cx - cpx, top, cx, top);
+    plutovg_path_close(path);
+}
+
+void plutovg_path_add_circle(plutovg_path_t* path, double cx, double cy, double r)
+{
+    plutovg_path_add_ellipse(path, cx, cy, r, r);
+}
+
+void plutovg_path_add_path(plutovg_path_t* path, const plutovg_path_t* source, const plutovg_matrix_t* matrix)
+{
+    for (auto& iter: source->elements)
+    {
+        path->elements.emplace_back(iter);
+    }
+
+    for (auto& iter: source->points)
+    {
+        path->points.emplace_back(iter);
+        if (matrix)
+        {
+            auto& dst = path->points.back();
+            plutovg_matrix_map(matrix, iter.x, iter.y, &dst.x, &dst.y);
+        }
+    }
+
+    path->contours += source->contours;
+    path->start = source->start;
+}
+
+void plutovg_path_transform(plutovg_path_t* path, const plutovg_matrix_t* matrix)
+{
+    for (int i = 0; i < path->points.size(); i++)
+    {
+        plutovg_matrix_map_point(matrix, &path->points[i], &path->points[i]);
+    }
+}
+
+void plutovg_path_get_current_point(const plutovg_path_t* path, double* x, double* y)
+{
+    if (path->points.empty())
+    {
+        *x = 0.0;
+        *y = 0.0;
+        return;
+    }
+
+    *x = path->points.back().x;
+    *y = path->points.back().y;
+}
+
+int plutovg_path_get_element_count(const plutovg_path_t* path)
+{
+    return static_cast<int>(path->elements.size());
+}
+const plutovg_path_element_t* plutovg_path_get_elements(const plutovg_path_t* path)
+{
+    return path->elements.data();
+}
+
+int plutovg_path_get_point_count(const plutovg_path_t* path)
+{
+    return static_cast<int>(path->points.size());
+}
+
+const plutovg_point_t* plutovg_path_get_points(const plutovg_path_t* path)
+{
+    return path->points.data();
+}
+
+void plutovg_path_clear(plutovg_path_t* path)
+{
+    path->elements.clear();
+    path->points.clear();
+    path->contours = 0;
+    path->start.x = 0.0;
+    path->start.y = 0.0;
+}
+
+int plutovg_path_empty(const plutovg_path_t* path)
+{
+    return path->elements.empty();
+}
+
+plutovg_path_t* plutovg_path_clone(const plutovg_path_t* path)
+{
+    plutovg_path_t* result = plutovg_path_create();
+    result->elements = path->elements;
+    result->points = path->points;
+    result->contours = path->contours;
+    result->start = path->start;
+    return result;
+}
+
+typedef struct
+{
+    double x1;
+    double y1;
+    double x2;
+    double y2;
+    double x3;
+    double y3;
+    double x4;
+    double y4;
+} bezier_t;
+
+static inline void split(const bezier_t* b, bezier_t* first, bezier_t* second)
+{
+    double c = (b->x2 + b->x3) * 0.5;
+    first->x2 = (b->x1 + b->x2) * 0.5;
+    second->x3 = (b->x3 + b->x4) * 0.5;
+    first->x1 = b->x1;
+    second->x4 = b->x4;
+    first->x3 = (first->x2 + c) * 0.5;
+    second->x2 = (second->x3 + c) * 0.5;
+    first->x4 = second->x1 = (first->x3 + second->x2) * 0.5;
+
+    c = (b->y2 + b->y3) * 0.5;
+    first->y2 = (b->y1 + b->y2) * 0.5;
+    second->y3 = (b->y3 + b->y4) * 0.5;
+    first->y1 = b->y1;
+    second->y4 = b->y4;
+    first->y3 = (first->y2 + c) * 0.5;
+    second->y2 = (second->y3 + c) * 0.5;
+    first->y4 = second->y1 = (first->y3 + second->y2) * 0.5;
+}
+
+static void flatten(plutovg_path_t* path, const plutovg_point_t* p0, const plutovg_point_t* p1, const plutovg_point_t* p2,
+                    const plutovg_point_t* p3)
+{
+    bezier_t beziers[32];
+    beziers[0].x1 = p0->x;
+    beziers[0].y1 = p0->y;
+    beziers[0].x2 = p1->x;
+    beziers[0].y2 = p1->y;
+    beziers[0].x3 = p2->x;
+    beziers[0].y3 = p2->y;
+    beziers[0].x4 = p3->x;
+    beziers[0].y4 = p3->y;
+
+    const double threshold = 0.25;
+
+    bezier_t* b = beziers;
+    while (b >= beziers)
+    {
+        double y4y1 = b->y4 - b->y1;
+        double x4x1 = b->x4 - b->x1;
+        double l = fabs(x4x1) + fabs(y4y1);
+        double d;
+        if (l > 1.0)
+        {
+            d = fabs((x4x1) * (b->y1 - b->y2) - (y4y1) * (b->x1 - b->x2)) +
+                fabs((x4x1) * (b->y1 - b->y3) - (y4y1) * (b->x1 - b->x3));
+        }
+        else
+        {
+            d = fabs(b->x1 - b->x2) + fabs(b->y1 - b->y2) + fabs(b->x1 - b->x3) + fabs(b->y1 - b->y3);
+            l = 1.0;
+        }
+
+        if (d < threshold * l || b == beziers + 31)
+        {
+            plutovg_path_line_to(path, b->x4, b->y4);
+            --b;
+        }
+        else
+        {
+            split(b, b + 1, b);
+            ++b;
+        }
+    }
+}
+
+plutovg_path_t* plutovg_path_clone_flat(const plutovg_path_t* path)
+{
+    plutovg_path_t* result = plutovg_path_create();
+    for (auto& iter: path->points)
+    {
+        result->points.emplace_back(iter);
+    }
+
+    const plutovg_point_t* points = path->points.data();
+    for (auto& iter: path->elements)
+    {
+        switch (iter)
+        {
+            case plutovg_path_element_move_to:
+                plutovg_path_move_to(result, points[0].x, points[0].y);
+                points += 1;
+                break;
+            case plutovg_path_element_line_to:
+                plutovg_path_line_to(result, points[0].x, points[0].y);
+                points += 1;
+                break;
+            case plutovg_path_element_close:
+                plutovg_path_line_to(result, points[0].x, points[0].y);
+                points += 1;
+                break;
+            case plutovg_path_element_cubic_to:
+                {
+                    plutovg_point_t p0;
+                    plutovg_path_get_current_point(result, &p0.x, &p0.y);
+                    flatten(result, &p0, points, points + 1, points + 2);
+                    points += 3;
+                    break;
+                }
+        }
+    }
+
+    return result;
+}

--- a/source/plutovg/plutovg-paint.cpp
+++ b/source/plutovg/plutovg-paint.cpp
@@ -1,5 +1,8 @@
 #include "plutovg-private.h"
 
+#include <cstdlib>
+#include <cstring>
+
 void plutovg_color_init_rgb(plutovg_color_t* color, double r, double g, double b)
 {
     plutovg_color_init_rgba(color, r, g, b, 1.0);

--- a/source/plutovg/plutovg-paint.cpp
+++ b/source/plutovg/plutovg-paint.cpp
@@ -1,0 +1,308 @@
+#include "plutovg-private.h"
+
+void plutovg_color_init_rgb(plutovg_color_t* color, double r, double g, double b)
+{
+    plutovg_color_init_rgba(color, r, g, b, 1.0);
+}
+
+void plutovg_color_init_rgba(plutovg_color_t* color, double r, double g, double b, double a)
+{
+    color->r = plutovg_clamp(r, 0.0, 1.0);
+    color->g = plutovg_clamp(g, 0.0, 1.0);
+    color->b = plutovg_clamp(b, 0.0, 1.0);
+    color->a = plutovg_clamp(a, 0.0, 1.0);
+}
+
+void plutovg_gradient_init_linear(plutovg_gradient_t* gradient, double x1, double y1, double x2, double y2)
+{
+    gradient->type = plutovg_gradient_type_linear;
+    gradient->spread = plutovg_spread_method_pad;
+    gradient->opacity = 1.0;
+    gradient->stops.size = 0;
+    plutovg_matrix_init_identity(&gradient->matrix);
+    plutovg_gradient_set_values_linear(gradient, x1, y1, x2, y2);
+}
+
+void plutovg_gradient_init_radial(plutovg_gradient_t* gradient, double cx, double cy, double cr, double fx, double fy,
+                                  double fr)
+{
+    gradient->type = plutovg_gradient_type_radial;
+    gradient->spread = plutovg_spread_method_pad;
+    gradient->opacity = 1.0;
+    gradient->stops.size = 0;
+    plutovg_matrix_init_identity(&gradient->matrix);
+    plutovg_gradient_set_values_radial(gradient, cx, cy, cr, fx, fy, fr);
+}
+
+void plutovg_gradient_set_spread(plutovg_gradient_t* gradient, plutovg_spread_method_t spread)
+{
+    gradient->spread = spread;
+}
+
+plutovg_spread_method_t plutovg_gradient_get_spread(const plutovg_gradient_t* gradient)
+{
+    return gradient->spread;
+}
+
+void plutovg_gradient_set_matrix(plutovg_gradient_t* gradient, const plutovg_matrix_t* matrix)
+{
+    gradient->matrix = *matrix;
+}
+
+void plutovg_gradient_get_matrix(const plutovg_gradient_t* gradient, plutovg_matrix_t* matrix)
+{
+    *matrix = gradient->matrix;
+}
+
+void plutovg_gradient_add_stop_rgb(plutovg_gradient_t* gradient, double offset, double r, double g, double b)
+{
+    plutovg_gradient_add_stop_rgba(gradient, offset, r, g, b, 1.0);
+}
+
+void plutovg_gradient_add_stop_rgba(plutovg_gradient_t* gradient, double offset, double r, double g, double b, double a)
+{
+    if (offset < 0.0)
+        offset = 0.0;
+    if (offset > 1.0)
+        offset = 1.0;
+
+    if (gradient->stops.size + 1 > gradient->stops.capacity)
+    {
+        int capacity = gradient->stops.size + 1;
+        int newcapacity = gradient->stops.capacity == 0 ? 8 : gradient->stops.capacity;
+        while (newcapacity < capacity)
+        {
+            newcapacity *= 2;
+        }
+        gradient->stops.data = static_cast<plutovg_gradient_stop_t*>(
+            realloc(gradient->stops.data, newcapacity * sizeof(gradient->stops.data[0])));
+        gradient->stops.capacity = newcapacity;
+    }
+
+    plutovg_gradient_stop_t* stops = gradient->stops.data;
+    int nstops = gradient->stops.size;
+    int i = 0;
+    for (; i < nstops; i++)
+    {
+        if (offset < stops[i].offset)
+        {
+            memmove(&stops[i + 1], &stops[i], (size_t) (nstops - i) * sizeof(plutovg_gradient_stop_t));
+            break;
+        }
+    }
+
+    plutovg_gradient_stop_t* stop = &stops[i];
+    stop->offset = offset;
+    plutovg_color_init_rgba(&stop->color, r, g, b, a);
+    gradient->stops.size += 1;
+}
+
+void plutovg_gradient_add_stop_color(plutovg_gradient_t* gradient, double offset, const plutovg_color_t* color)
+{
+    plutovg_gradient_add_stop_rgba(gradient, offset, color->r, color->g, color->b, color->a);
+}
+
+void plutovg_gradient_add_stop(plutovg_gradient_t* gradient, const plutovg_gradient_stop_t* stop)
+{
+    plutovg_gradient_add_stop_rgba(gradient, stop->offset, stop->color.r, stop->color.g, stop->color.b, stop->color.a);
+}
+
+void plutovg_gradient_clear_stops(plutovg_gradient_t* gradient)
+{
+    gradient->stops.size = 0;
+}
+
+int plutovg_gradient_get_stop_count(const plutovg_gradient_t* gradient)
+{
+    return gradient->stops.size;
+}
+
+plutovg_gradient_stop_t* plutovg_gradient_get_stops(const plutovg_gradient_t* gradient)
+{
+    return gradient->stops.data;
+}
+
+plutovg_gradient_type_t plutovg_gradient_get_type(const plutovg_gradient_t* gradient)
+{
+    return gradient->type;
+}
+
+void plutovg_gradient_get_values_linear(const plutovg_gradient_t* gradient, double* x1, double* y1, double* x2, double* y2)
+{
+    if (x1)
+        *x1 = gradient->values[0];
+    if (y1)
+        *y1 = gradient->values[1];
+    if (x2)
+        *x2 = gradient->values[2];
+    if (y2)
+        *y2 = gradient->values[3];
+}
+
+void plutovg_gradient_get_values_radial(const plutovg_gradient_t* gradient, double* cx, double* cy, double* cr, double* fx,
+                                        double* fy, double* fr)
+{
+    if (cx)
+        *cx = gradient->values[0];
+    if (cy)
+        *cy = gradient->values[1];
+    if (cr)
+        *cr = gradient->values[2];
+    if (fx)
+        *fx = gradient->values[3];
+    if (fy)
+        *fy = gradient->values[4];
+    if (fr)
+        *fr = gradient->values[5];
+}
+
+void plutovg_gradient_set_values_linear(plutovg_gradient_t* gradient, double x1, double y1, double x2, double y2)
+{
+    gradient->values[0] = x1;
+    gradient->values[1] = y1;
+    gradient->values[2] = x2;
+    gradient->values[3] = y2;
+}
+
+void plutovg_gradient_set_values_radial(plutovg_gradient_t* gradient, double cx, double cy, double cr, double fx, double fy,
+                                        double fr)
+{
+    gradient->values[0] = cx;
+    gradient->values[1] = cy;
+    gradient->values[2] = cr;
+    gradient->values[3] = fx;
+    gradient->values[4] = fy;
+    gradient->values[5] = fr;
+}
+
+void plutovg_gradient_set_opacity(plutovg_gradient_t* gradient, double opacity)
+{
+    gradient->opacity = plutovg_clamp(opacity, 0.0, 1.0);
+}
+
+double plutovg_gradient_get_opacity(const plutovg_gradient_t* gradient)
+{
+    return gradient->opacity;
+}
+
+void plutovg_gradient_copy(plutovg_gradient_t* gradient, const plutovg_gradient_t* source)
+{
+    gradient->type = source->type;
+    gradient->spread = source->spread;
+    gradient->matrix = source->matrix;
+    gradient->opacity = source->opacity;
+    if (gradient->stops.size + source->stops.size > gradient->stops.capacity)
+    {
+        int capacity = gradient->stops.size + source->stops.size;
+        int newcapacity = gradient->stops.capacity == 0 ? 8 : gradient->stops.capacity;
+        while (newcapacity < capacity)
+        {
+            newcapacity *= 2;
+        }
+        gradient->stops.data = static_cast<plutovg_gradient_stop_t*>(
+            realloc(gradient->stops.data, newcapacity * sizeof(gradient->stops.data[0])));
+        gradient->stops.capacity = newcapacity;
+    }
+
+    memcpy(gradient->values, source->values, sizeof(source->values));
+    memcpy(gradient->stops.data, source->stops.data, source->stops.size * sizeof(plutovg_gradient_stop_t));
+}
+
+void plutovg_gradient_destroy(plutovg_gradient_t* gradient)
+{
+    free(gradient->stops.data);
+}
+
+void plutovg_texture_init(plutovg_texture_t* texture, plutovg_surface_t* surface, plutovg_texture_type_t type)
+{
+    surface = plutovg_surface_reference(surface);
+    plutovg_surface_destroy(texture->surface);
+    texture->type = type;
+    texture->surface = surface;
+    texture->opacity = 1.0;
+    plutovg_matrix_init_identity(&texture->matrix);
+}
+
+void plutovg_texture_set_type(plutovg_texture_t* texture, plutovg_texture_type_t type)
+{
+    texture->type = type;
+}
+
+plutovg_texture_type_t plutovg_texture_get_type(const plutovg_texture_t* texture)
+{
+    return texture->type;
+}
+
+void plutovg_texture_set_matrix(plutovg_texture_t* texture, const plutovg_matrix_t* matrix)
+{
+    texture->matrix = *matrix;
+}
+
+void plutovg_texture_get_matrix(const plutovg_texture_t* texture, plutovg_matrix_t* matrix)
+{
+    *matrix = texture->matrix;
+}
+
+void plutovg_texture_set_surface(plutovg_texture_t* texture, plutovg_surface_t* surface)
+{
+    surface = plutovg_surface_reference(surface);
+    plutovg_surface_destroy(texture->surface);
+    texture->surface = surface;
+}
+
+plutovg_surface_t* plutovg_texture_get_surface(const plutovg_texture_t* texture)
+{
+    return texture->surface;
+}
+
+void plutovg_texture_set_opacity(plutovg_texture_t* texture, double opacity)
+{
+    texture->opacity = plutovg_clamp(opacity, 0.0, 1.0);
+}
+
+double plutovg_texture_get_opacity(const plutovg_texture_t* texture)
+{
+    return texture->opacity;
+}
+
+void plutovg_texture_copy(plutovg_texture_t* texture, const plutovg_texture_t* source)
+{
+    plutovg_surface_t* surface = plutovg_surface_reference(source->surface);
+    plutovg_surface_destroy(texture->surface);
+    texture->type = source->type;
+    texture->surface = surface;
+    texture->opacity = source->opacity;
+    texture->matrix = source->matrix;
+}
+
+void plutovg_texture_destroy(plutovg_texture_t* texture)
+{
+    plutovg_surface_destroy(texture->surface);
+}
+
+void plutovg_paint_init(plutovg_paint_t* paint)
+{
+    paint->type = plutovg_paint_type_color;
+    paint->texture.surface = NULL;
+    paint->gradient.stops.data = nullptr;
+    paint->gradient.stops.size = 0;
+    paint->gradient.stops.capacity = 0;
+    plutovg_color_init_rgb(&paint->color, 0, 0, 0);
+}
+
+void plutovg_paint_destroy(plutovg_paint_t* paint)
+{
+    plutovg_texture_destroy(&paint->texture);
+    plutovg_gradient_destroy(&paint->gradient);
+}
+
+void plutovg_paint_copy(plutovg_paint_t* paint, const plutovg_paint_t* source)
+{
+    paint->type = source->type;
+    if (source->type == plutovg_paint_type_color)
+        paint->color = source->color;
+    else if (source->type == plutovg_paint_type_color)
+        plutovg_gradient_copy(&paint->gradient, &paint->gradient);
+    else
+        plutovg_texture_copy(&paint->texture, &paint->texture);
+}

--- a/source/plutovg/plutovg-private.h
+++ b/source/plutovg/plutovg-private.h
@@ -1,0 +1,181 @@
+#ifndef PLUTOVG_PRIVATE_H
+#define PLUTOVG_PRIVATE_H
+
+#include <vector>
+
+#include "plutovg.h"
+
+struct plutovg_surface
+{
+    int ref;
+    unsigned char* data;
+    int owndata;
+    int width;
+    int height;
+    int stride;
+};
+
+struct plutovg_path
+{
+    int ref = 1;
+    int contours = 0;
+    plutovg_point_t start = { 0.0, 0.0 };
+    std::vector<plutovg_path_element_t> elements;
+    std::vector<plutovg_point_t> points;
+};
+
+struct plutovg_gradient
+{
+    int ref;
+    plutovg_gradient_type_t type;
+    plutovg_spread_method_t spread;
+    plutovg_matrix_t matrix;
+    double values[6];
+    double opacity;
+    struct
+    {
+        plutovg_gradient_stop_t* data;
+        int size;
+        int capacity;
+    } stops;
+};
+
+struct plutovg_texture
+{
+    int ref;
+    plutovg_texture_type_t type;
+    plutovg_surface_t* surface;
+    plutovg_matrix_t matrix;
+    double opacity;
+};
+
+typedef int plutovg_paint_type_t;
+
+enum
+{
+    plutovg_paint_type_color,
+    plutovg_paint_type_gradient,
+    plutovg_paint_type_texture
+};
+
+typedef struct
+{
+    plutovg_paint_type_t type;
+    plutovg_color_t color;
+    plutovg_gradient_t gradient;
+    plutovg_texture_t texture;
+} plutovg_paint_t;
+
+typedef struct
+{
+    int x;
+    int len;
+    int y;
+    unsigned char coverage;
+} plutovg_span_t;
+
+typedef struct
+{
+    struct {
+        plutovg_span_t* data;
+        int size;
+        int capacity;
+    } spans;
+
+    int x;
+    int y;
+    int w;
+    int h;
+} plutovg_rle_t;
+
+typedef struct
+{
+    double offset;
+    double* data;
+    int size;
+} plutovg_dash_t;
+
+typedef struct
+{
+    double width;
+    double miterlimit;
+    plutovg_line_cap_t cap;
+    plutovg_line_join_t join;
+    plutovg_dash_t* dash;
+} plutovg_stroke_data_t;
+
+typedef struct plutovg_state
+{
+    plutovg_rle_t* clippath;
+    plutovg_paint_t paint;
+    plutovg_matrix_t matrix;
+    plutovg_fill_rule_t winding;
+    plutovg_stroke_data_t stroke;
+    plutovg_operator_t op;
+    double opacity;
+    struct plutovg_state* next;
+} plutovg_state_t;
+
+struct plutovg
+{
+    int ref;
+    plutovg_surface_t* surface;
+    plutovg_state_t* state;
+    plutovg_path_t* path;
+    plutovg_rle_t* rle;
+    plutovg_rle_t* clippath;
+    plutovg_rect_t clip;
+    void* outline_data;
+    size_t outline_size;
+};
+
+void plutovg_paint_init(plutovg_paint_t* paint);
+void plutovg_paint_destroy(plutovg_paint_t* paint);
+void plutovg_paint_copy(plutovg_paint_t* paint, const plutovg_paint_t* source);
+
+void plutovg_gradient_copy(plutovg_gradient_t* gradient, const plutovg_gradient_t* source);
+void plutovg_gradient_destroy(plutovg_gradient_t* gradient);
+
+void plutovg_texture_copy(plutovg_texture_t* texture, const plutovg_texture_t* source);
+void plutovg_texture_destroy(plutovg_texture_t* texture);
+
+plutovg_rle_t* plutovg_rle_create(void);
+void plutovg_rle_destroy(plutovg_rle_t* rle);
+void plutovg_rle_rasterize(plutovg_t* pluto, plutovg_rle_t* rle, const plutovg_path_t* path, const plutovg_matrix_t* matrix,
+                           const plutovg_rect_t* clip, const plutovg_stroke_data_t* stroke, plutovg_fill_rule_t winding);
+plutovg_rle_t* plutovg_rle_intersection(const plutovg_rle_t* a, const plutovg_rle_t* b);
+void plutovg_rle_clip_path(plutovg_rle_t* rle, const plutovg_rle_t* clip);
+plutovg_rle_t* plutovg_rle_clone(const plutovg_rle_t* rle);
+void plutovg_rle_clear(plutovg_rle_t* rle);
+
+plutovg_dash_t* plutovg_dash_create(double offset, const double* data, int size);
+plutovg_dash_t* plutovg_dash_clone(const plutovg_dash_t* dash);
+void plutovg_dash_destroy(plutovg_dash_t* dash);
+plutovg_path_t* plutovg_dash_path(const plutovg_dash_t* dash, const plutovg_path_t* path);
+
+plutovg_state_t* plutovg_state_create(void);
+plutovg_state_t* plutovg_state_clone(const plutovg_state_t* state);
+void plutovg_state_destroy(plutovg_state_t* state);
+
+void plutovg_blend(plutovg_t* pluto, const plutovg_rle_t* rle);
+void plutovg_blend_color(plutovg_t* pluto, const plutovg_rle_t* rle, const plutovg_color_t* color);
+void plutovg_blend_gradient(plutovg_t* pluto, const plutovg_rle_t* rle, const plutovg_gradient_t* gradient);
+void plutovg_blend_texture(plutovg_t* pluto, const plutovg_rle_t* rle, const plutovg_texture_t* texture);
+
+#define plutovg_sqrt2   1.41421356237309504880
+#define plutovg_pi      3.14159265358979323846
+#define plutovg_two_pi  6.28318530717958647693
+#define plutovg_half_pi 1.57079632679489661923
+#define plutovg_kappa   0.55228474983079339840
+
+#define plutovg_min(a, b)        ((a) < (b) ? (a) : (b))
+#define plutovg_max(a, b)        ((a) > (b) ? (a) : (b))
+#define plutovg_clamp(v, lo, hi) ((v) < (lo) ? (lo) : (hi) < (v) ? (hi) : (v))
+#define plutovg_div255(x)        (((x) + ((x) >> 8) + 0x80) >> 8)
+
+#define plutovg_alpha(c) ((c) >> 24)
+#define plutovg_red(c)   (((c) >> 16) & 0xff)
+#define plutovg_green(c) (((c) >> 8) & 0xff)
+#define plutovg_blue(c)  (((c) >> 0) & 0xff)
+
+#endif  // PLUTOVG_PRIVATE_H

--- a/source/plutovg/plutovg-rle.cpp
+++ b/source/plutovg/plutovg-rle.cpp
@@ -1,0 +1,495 @@
+#include "plutovg-private.h"
+
+#include "plutovg-ft-raster.h"
+#include "plutovg-ft-stroker.h"
+
+#include <limits.h>
+#include <math.h>
+
+#define ALIGN_SIZE(size) (((size) + 7ul) & ~7ul)
+static void ft_outline_init(PVG_FT_Outline* outline, plutovg_t* pluto, int points, int contours)
+{
+    size_t size_a = ALIGN_SIZE((points + contours) * sizeof(PVG_FT_Vector));
+    size_t size_b = ALIGN_SIZE((points + contours) * sizeof(char));
+    size_t size_c = ALIGN_SIZE(contours * sizeof(int));
+    size_t size_d = ALIGN_SIZE(contours * sizeof(char));
+    size_t size_n = size_a + size_b + size_c + size_d;
+    if (size_n > pluto->outline_size)
+    {
+        pluto->outline_data = realloc(pluto->outline_data, size_n);
+        pluto->outline_size = size_n;
+    }
+
+    PVG_FT_Byte* data = static_cast<PVG_FT_Byte*>(pluto->outline_data);
+    outline->points = (PVG_FT_Vector*) (data);
+    outline->tags = outline->contours_flag = nullptr;
+    outline->contours = nullptr;
+    if (data)
+    {
+        outline->tags = (char*) (data + size_a);
+        outline->contours = (int*) (data + size_a + size_b);
+        outline->contours_flag = (char*) (data + size_a + size_b + size_c);
+    }
+    outline->n_points = 0;
+    outline->n_contours = 0;
+    outline->flags = 0x0;
+}
+
+#define FT_COORD(x) (PVG_FT_Pos)((x) *64)
+static void ft_outline_move_to(PVG_FT_Outline* ft, double x, double y)
+{
+    ft->points[ft->n_points].x = FT_COORD(x);
+    ft->points[ft->n_points].y = FT_COORD(y);
+    ft->tags[ft->n_points] = PVG_FT_CURVE_TAG_ON;
+    if (ft->n_points)
+    {
+        ft->contours[ft->n_contours] = ft->n_points - 1;
+        ft->n_contours++;
+    }
+
+    ft->contours_flag[ft->n_contours] = 1;
+    ft->n_points++;
+}
+
+static void ft_outline_line_to(PVG_FT_Outline* ft, double x, double y)
+{
+    ft->points[ft->n_points].x = FT_COORD(x);
+    ft->points[ft->n_points].y = FT_COORD(y);
+    ft->tags[ft->n_points] = PVG_FT_CURVE_TAG_ON;
+    ft->n_points++;
+}
+
+static void ft_outline_cubic_to(PVG_FT_Outline* ft, double x1, double y1, double x2, double y2, double x3, double y3)
+{
+    ft->points[ft->n_points].x = FT_COORD(x1);
+    ft->points[ft->n_points].y = FT_COORD(y1);
+    ft->tags[ft->n_points] = PVG_FT_CURVE_TAG_CUBIC;
+    ft->n_points++;
+
+    ft->points[ft->n_points].x = FT_COORD(x2);
+    ft->points[ft->n_points].y = FT_COORD(y2);
+    ft->tags[ft->n_points] = PVG_FT_CURVE_TAG_CUBIC;
+    ft->n_points++;
+
+    ft->points[ft->n_points].x = FT_COORD(x3);
+    ft->points[ft->n_points].y = FT_COORD(y3);
+    ft->tags[ft->n_points] = PVG_FT_CURVE_TAG_ON;
+    ft->n_points++;
+}
+
+static void ft_outline_close(PVG_FT_Outline* ft)
+{
+    ft->contours_flag[ft->n_contours] = 0;
+    int index = ft->n_contours ? ft->contours[ft->n_contours - 1] + 1 : 0;
+    if (index == ft->n_points)
+        return;
+
+    ft->points[ft->n_points].x = ft->points[index].x;
+    ft->points[ft->n_points].y = ft->points[index].y;
+    ft->tags[ft->n_points] = PVG_FT_CURVE_TAG_ON;
+    ft->n_points++;
+}
+
+static void ft_outline_end(PVG_FT_Outline* ft)
+{
+    if (ft->n_points)
+    {
+        ft->contours[ft->n_contours] = ft->n_points - 1;
+        ft->n_contours++;
+    }
+}
+
+static void ft_outline_convert(PVG_FT_Outline* outline, plutovg_t* pluto, const plutovg_path_t* path,
+                               const plutovg_matrix_t* matrix)
+{
+    ft_outline_init(outline, pluto, (int) path->points.size(), path->contours);
+    const plutovg_point_t* points = path->points.data();
+    plutovg_point_t p[3];
+    for (auto& iter: path->elements)
+    {
+        switch (iter)
+        {
+            case plutovg_path_element_move_to:
+                plutovg_matrix_map_point(matrix, &points[0], &p[0]);
+                ft_outline_move_to(outline, p[0].x, p[0].y);
+                points += 1;
+                break;
+            case plutovg_path_element_line_to:
+                plutovg_matrix_map_point(matrix, &points[0], &p[0]);
+                ft_outline_line_to(outline, p[0].x, p[0].y);
+                points += 1;
+                break;
+            case plutovg_path_element_cubic_to:
+                plutovg_matrix_map_point(matrix, &points[0], &p[0]);
+                plutovg_matrix_map_point(matrix, &points[1], &p[1]);
+                plutovg_matrix_map_point(matrix, &points[2], &p[2]);
+                ft_outline_cubic_to(outline, p[0].x, p[0].y, p[1].x, p[1].y, p[2].x, p[2].y);
+                points += 3;
+                break;
+            case plutovg_path_element_close:
+                ft_outline_close(outline);
+                points += 1;
+                break;
+        }
+    }
+
+    ft_outline_end(outline);
+}
+
+static void ft_outline_convert_dash(PVG_FT_Outline* outline, plutovg_t* pluto, const plutovg_path_t* path,
+                                    const plutovg_matrix_t* matrix, const plutovg_dash_t* dash)
+{
+    plutovg_path_t* dashed = plutovg_dash_path(dash, path);
+    ft_outline_convert(outline, pluto, dashed, matrix);
+    plutovg_path_destroy(dashed);
+}
+
+static void generation_callback(int count, const PVG_FT_Span* spans, void* user)
+{
+    plutovg_rle_t* rle = static_cast<plutovg_rle_t*>(user);
+    if (rle->spans.size + count > rle->spans.capacity)
+    {
+        int capacity = rle->spans.size + count;
+        int newcapacity = rle->spans.capacity == 0 ? 8 : rle->spans.capacity;
+        while (newcapacity < capacity)
+        {
+            newcapacity *= 2;
+        }
+        rle->spans.data = static_cast<plutovg_span_t*>(realloc(rle->spans.data, newcapacity * sizeof(rle->spans.data[0])));
+        rle->spans.capacity = newcapacity;
+    }
+
+    plutovg_span_t* data = rle->spans.data + rle->spans.size;
+    memcpy(data, spans, (size_t) count * sizeof(plutovg_span_t));
+    rle->spans.size += count;
+}
+
+plutovg_rle_t* plutovg_rle_create(void)
+{
+    plutovg_rle_t* rle = new plutovg_rle_t;
+    rle->spans.data = nullptr;
+    rle->spans.size = 0;
+    rle->spans.capacity = 0;
+    rle->x = 0;
+    rle->y = 0;
+    rle->w = 0;
+    rle->h = 0;
+    return rle;
+}
+
+void plutovg_rle_destroy(plutovg_rle_t* rle)
+{
+    if (rle == nullptr)
+        return;
+
+    free(rle->spans.data);
+    delete rle;
+}
+
+void plutovg_rle_rasterize(plutovg_t* pluto, plutovg_rle_t* rle, const plutovg_path_t* path, const plutovg_matrix_t* matrix,
+                           const plutovg_rect_t* clip, const plutovg_stroke_data_t* stroke, plutovg_fill_rule_t winding)
+{
+    PVG_FT_Raster_Params params;
+    params.flags = PVG_FT_RASTER_FLAG_DIRECT | PVG_FT_RASTER_FLAG_AA;
+    params.gray_spans = generation_callback;
+    params.user = rle;
+    if (clip)
+    {
+        params.flags |= PVG_FT_RASTER_FLAG_CLIP;
+        params.clip_box.xMin = (PVG_FT_Pos) (clip->x);
+        params.clip_box.yMin = (PVG_FT_Pos) (clip->y);
+        params.clip_box.xMax = (PVG_FT_Pos) (clip->x + clip->w);
+        params.clip_box.yMax = (PVG_FT_Pos) (clip->y + clip->h);
+    }
+
+    if (stroke)
+    {
+        PVG_FT_Outline outline;
+        if (stroke->dash == nullptr)
+            ft_outline_convert(&outline, pluto, path, matrix);
+        else
+            ft_outline_convert_dash(&outline, pluto, path, matrix, stroke->dash);
+        PVG_FT_Stroker_LineCap ftCap;
+        PVG_FT_Stroker_LineJoin ftJoin;
+        PVG_FT_Fixed ftWidth;
+        PVG_FT_Fixed ftMiterLimit;
+
+        plutovg_point_t p1 = { 0, 0 };
+        plutovg_point_t p2 = { plutovg_sqrt2, plutovg_sqrt2 };
+        plutovg_point_t p3;
+
+        plutovg_matrix_map_point(matrix, &p1, &p1);
+        plutovg_matrix_map_point(matrix, &p2, &p2);
+
+        p3.x = p2.x - p1.x;
+        p3.y = p2.y - p1.y;
+
+        double scale = sqrt(p3.x * p3.x + p3.y * p3.y) / 2.0;
+
+        ftWidth = (PVG_FT_Fixed) (stroke->width * scale * 0.5 * (1 << 6));
+        ftMiterLimit = (PVG_FT_Fixed) (stroke->miterlimit * (1 << 16));
+
+        switch (stroke->cap)
+        {
+            case plutovg_line_cap_square:
+                ftCap = PVG_FT_STROKER_LINECAP_SQUARE;
+                break;
+            case plutovg_line_cap_round:
+                ftCap = PVG_FT_STROKER_LINECAP_ROUND;
+                break;
+            default:
+                ftCap = PVG_FT_STROKER_LINECAP_BUTT;
+                break;
+        }
+
+        switch (stroke->join)
+        {
+            case plutovg_line_join_bevel:
+                ftJoin = PVG_FT_STROKER_LINEJOIN_BEVEL;
+                break;
+            case plutovg_line_join_round:
+                ftJoin = PVG_FT_STROKER_LINEJOIN_ROUND;
+                break;
+            default:
+                ftJoin = PVG_FT_STROKER_LINEJOIN_MITER_FIXED;
+                break;
+        }
+
+        PVG_FT_Stroker stroker;
+        PVG_FT_Stroker_New(&stroker);
+        PVG_FT_Stroker_Set(stroker, ftWidth, ftCap, ftJoin, ftMiterLimit);
+        PVG_FT_Stroker_ParseOutline(stroker, &outline);
+
+        PVG_FT_UInt points;
+        PVG_FT_UInt contours;
+        PVG_FT_Stroker_GetCounts(stroker, &points, &contours);
+
+        ft_outline_init(&outline, pluto, points, contours);
+        PVG_FT_Stroker_Export(stroker, &outline);
+        PVG_FT_Stroker_Done(stroker);
+
+        outline.flags = PVG_FT_OUTLINE_NONE;
+        params.source = &outline;
+        PVG_FT_Raster_Render(&params);
+    }
+    else
+    {
+        PVG_FT_Outline outline;
+        ft_outline_convert(&outline, pluto, path, matrix);
+        switch (winding)
+        {
+            case plutovg_fill_rule_even_odd:
+                outline.flags = PVG_FT_OUTLINE_EVEN_ODD_FILL;
+                break;
+            default:
+                outline.flags = PVG_FT_OUTLINE_NONE;
+                break;
+        }
+
+        params.source = &outline;
+        PVG_FT_Raster_Render(&params);
+    }
+
+    if (rle->spans.size == 0)
+    {
+        rle->x = 0;
+        rle->y = 0;
+        rle->w = 0;
+        rle->h = 0;
+        return;
+    }
+
+    plutovg_span_t* spans = rle->spans.data;
+    int x1 = INT_MAX;
+    int y1 = spans[0].y;
+    int x2 = 0;
+    int y2 = spans[rle->spans.size - 1].y;
+    for (int i = 0; i < rle->spans.size; i++)
+    {
+        if (spans[i].x < x1)
+            x1 = spans[i].x;
+        if (spans[i].x + spans[i].len > x2)
+            x2 = spans[i].x + spans[i].len;
+    }
+
+    rle->x = x1;
+    rle->y = y1;
+    rle->w = x2 - x1;
+    rle->h = y2 - y1 + 1;
+}
+
+plutovg_rle_t* plutovg_rle_intersection(const plutovg_rle_t* a, const plutovg_rle_t* b)
+{
+    int count = plutovg_max(a->spans.size, b->spans.size);
+    plutovg_rle_t* result = new plutovg_rle_t;
+
+    result->spans.data = nullptr;
+    result->spans.size = 0;
+    result->spans.capacity = 0;
+    if (result->spans.size + count > result->spans.capacity)
+    {
+        int capacity = result->spans.size + count;
+        int newcapacity = result->spans.capacity == 0 ? 8 : result->spans.capacity;
+        while (newcapacity < capacity)
+        {
+            newcapacity *= 2;
+        }
+        result->spans.data =
+            static_cast<plutovg_span_t*>(realloc(result->spans.data, newcapacity * sizeof(result->spans.data[0])));
+        result->spans.capacity = newcapacity;
+    }
+
+    plutovg_span_t* a_spans = a->spans.data;
+    plutovg_span_t* a_end = a_spans + a->spans.size;
+
+    plutovg_span_t* b_spans = b->spans.data;
+    plutovg_span_t* b_end = b_spans + b->spans.size;
+
+    while (count && a_spans < a_end && b_spans < b_end)
+    {
+        if (b_spans->y > a_spans->y)
+        {
+            ++a_spans;
+            continue;
+        }
+
+        if (a_spans->y != b_spans->y)
+        {
+            ++b_spans;
+            continue;
+        }
+
+        int ax1 = a_spans->x;
+        int ax2 = ax1 + a_spans->len;
+        int bx1 = b_spans->x;
+        int bx2 = bx1 + b_spans->len;
+
+        if (bx1 < ax1 && bx2 < ax1)
+        {
+            ++b_spans;
+            continue;
+        }
+        else if (ax1 < bx1 && ax2 < bx1)
+        {
+            ++a_spans;
+            continue;
+        }
+
+        int x = plutovg_max(ax1, bx1);
+        int len = plutovg_min(ax2, bx2) - x;
+        if (len)
+        {
+            plutovg_span_t* span = result->spans.data + result->spans.size;
+            span->x = (short) x;
+            span->len = (unsigned short) len;
+            span->y = a_spans->y;
+            span->coverage = plutovg_div255(a_spans->coverage * b_spans->coverage);
+            ++result->spans.size;
+            --count;
+        }
+
+        if (ax2 < bx2)
+        {
+            ++a_spans;
+        }
+        else
+        {
+            ++b_spans;
+        }
+    }
+
+    if (result->spans.size == 0)
+    {
+        result->x = 0;
+        result->y = 0;
+        result->w = 0;
+        result->h = 0;
+        return result;
+    }
+
+    plutovg_span_t* spans = result->spans.data;
+    int x1 = INT_MAX;
+    int y1 = spans[0].y;
+    int x2 = 0;
+    int y2 = spans[result->spans.size - 1].y;
+    for (int i = 0; i < result->spans.size; i++)
+    {
+        if (spans[i].x < x1)
+            x1 = spans[i].x;
+        if (spans[i].x + spans[i].len > x2)
+            x2 = spans[i].x + spans[i].len;
+    }
+
+    result->x = x1;
+    result->y = y1;
+    result->w = x2 - x1;
+    result->h = y2 - y1 + 1;
+    return result;
+}
+
+void plutovg_rle_clip_path(plutovg_rle_t* rle, const plutovg_rle_t* clip)
+{
+    if (rle == nullptr || clip == nullptr)
+        return;
+
+    plutovg_rle_t* result = plutovg_rle_intersection(rle, clip);
+    if (rle->spans.size + result->spans.size > rle->spans.capacity)
+    {
+        int capacity = rle->spans.size + result->spans.size;
+        int newcapacity = rle->spans.capacity == 0 ? 8 : rle->spans.capacity;
+        while (newcapacity < capacity)
+        {
+            newcapacity *= 2;
+        }
+        rle->spans.data = static_cast<plutovg_span_t*>(realloc(rle->spans.data, newcapacity * sizeof(rle->spans.data[0])));
+        rle->spans.capacity = newcapacity;
+    }
+
+    memcpy(rle->spans.data, result->spans.data, (size_t) result->spans.size * sizeof(plutovg_span_t));
+    rle->spans.size = result->spans.size;
+    rle->x = result->x;
+    rle->y = result->y;
+    rle->w = result->w;
+    rle->h = result->h;
+    plutovg_rle_destroy(result);
+}
+
+plutovg_rle_t* plutovg_rle_clone(const plutovg_rle_t* rle)
+{
+    if (rle == nullptr)
+        return nullptr;
+
+    plutovg_rle_t* result = new plutovg_rle_t;
+    result->spans.data = nullptr;
+    result->spans.size = 0;
+    result->spans.capacity = 0;
+    if (result->spans.size + rle->spans.size > result->spans.capacity)
+    {
+        int capacity = result->spans.size + rle->spans.size;
+        int newcapacity = result->spans.capacity == 0 ? 8 : result->spans.capacity;
+        while (newcapacity < capacity)
+        {
+            newcapacity *= 2;
+        }
+        result->spans.data =
+            static_cast<plutovg_span_t*>(realloc(result->spans.data, newcapacity * sizeof(result->spans.data[0])));
+        result->spans.capacity = newcapacity;
+    }
+
+    memcpy(result->spans.data, rle->spans.data, (size_t) rle->spans.size * sizeof(plutovg_span_t));
+    result->spans.size = rle->spans.size;
+    result->x = rle->x;
+    result->y = rle->y;
+    result->w = rle->w;
+    result->h = rle->h;
+    return result;
+}
+
+void plutovg_rle_clear(plutovg_rle_t* rle)
+{
+    rle->spans.size = 0;
+    rle->x = 0;
+    rle->y = 0;
+    rle->w = 0;
+    rle->h = 0;
+}

--- a/source/plutovg/plutovg-rle.cpp
+++ b/source/plutovg/plutovg-rle.cpp
@@ -3,6 +3,7 @@
 #include "plutovg-ft-raster.h"
 #include "plutovg-ft-stroker.h"
 
+#include <cstring>
 #include <limits.h>
 #include <math.h>
 

--- a/source/plutovg/plutovg.cpp
+++ b/source/plutovg/plutovg.cpp
@@ -1,5 +1,7 @@
 #include "plutovg-private.h"
 
+#include <cstdlib>
+
 plutovg_surface_t* plutovg_surface_create(int width, int height)
 {
     plutovg_surface_t* surface = new plutovg_surface_t;

--- a/source/plutovg/plutovg.cpp
+++ b/source/plutovg/plutovg.cpp
@@ -1,0 +1,497 @@
+#include "plutovg-private.h"
+
+plutovg_surface_t* plutovg_surface_create(int width, int height)
+{
+    plutovg_surface_t* surface = new plutovg_surface_t;
+    surface->ref = 1;
+    surface->owndata = 1;
+    surface->data = static_cast<unsigned char*>(calloc(1, (size_t) (width * height * 4)));
+    surface->width = width;
+    surface->height = height;
+    surface->stride = width * 4;
+    return surface;
+}
+
+plutovg_surface_t* plutovg_surface_create_for_data(unsigned char* data, int width, int height, int stride)
+{
+    plutovg_surface_t* surface = new plutovg_surface_t;
+    surface->ref = 1;
+    surface->owndata = 0;
+    surface->data = data;
+    surface->width = width;
+    surface->height = height;
+    surface->stride = stride;
+    return surface;
+}
+
+plutovg_surface_t* plutovg_surface_reference(plutovg_surface_t* surface)
+{
+    ++surface->ref;
+    return surface;
+}
+
+void plutovg_surface_destroy(plutovg_surface_t* surface)
+{
+    if (surface == nullptr)
+        return;
+
+    if (--surface->ref == 0)
+    {
+        if (surface->owndata)
+            free(surface->data);
+        delete surface;
+    }
+}
+
+int plutovg_surface_get_reference_count(const plutovg_surface_t* surface)
+{
+    return surface->ref;
+}
+
+unsigned char* plutovg_surface_get_data(const plutovg_surface_t* surface)
+{
+    return surface->data;
+}
+
+int plutovg_surface_get_width(const plutovg_surface_t* surface)
+{
+    return surface->width;
+}
+
+int plutovg_surface_get_height(const plutovg_surface_t* surface)
+{
+    return surface->height;
+}
+
+int plutovg_surface_get_stride(const plutovg_surface_t* surface)
+{
+    return surface->stride;
+}
+
+plutovg_state_t* plutovg_state_create(void)
+{
+    plutovg_state_t* state = new plutovg_state_t;
+    state->clippath = nullptr;
+    plutovg_paint_init(&state->paint);
+    plutovg_matrix_init_identity(&state->matrix);
+    state->winding = plutovg_fill_rule_non_zero;
+    state->stroke.width = 1.0;
+    state->stroke.miterlimit = 4.0;
+    state->stroke.cap = plutovg_line_cap_butt;
+    state->stroke.join = plutovg_line_join_miter;
+    state->stroke.dash = nullptr;
+    state->op = plutovg_operator_src_over;
+    state->opacity = 1.0;
+    state->next = nullptr;
+    return state;
+}
+
+plutovg_state_t* plutovg_state_clone(const plutovg_state_t* state)
+{
+    plutovg_state_t* newstate = plutovg_state_create();
+    newstate->clippath = plutovg_rle_clone(state->clippath);
+    plutovg_paint_copy(&newstate->paint, &state->paint);
+    newstate->matrix = state->matrix;
+    newstate->winding = state->winding;
+    newstate->stroke.width = state->stroke.width;
+    newstate->stroke.miterlimit = state->stroke.miterlimit;
+    newstate->stroke.cap = state->stroke.cap;
+    newstate->stroke.join = state->stroke.join;
+    newstate->stroke.dash = plutovg_dash_clone(state->stroke.dash);
+    newstate->op = state->op;
+    newstate->opacity = state->opacity;
+    newstate->next = nullptr;
+    return newstate;
+}
+
+void plutovg_state_destroy(plutovg_state_t* state)
+{
+    plutovg_rle_destroy(state->clippath);
+    plutovg_paint_destroy(&state->paint);
+    plutovg_dash_destroy(state->stroke.dash);
+    delete state;
+}
+
+plutovg_t* plutovg_create(plutovg_surface_t* surface)
+{
+    plutovg_t* pluto = new plutovg_t;
+    pluto->ref = 1;
+    pluto->surface = plutovg_surface_reference(surface);
+    pluto->state = plutovg_state_create();
+    pluto->path = plutovg_path_create();
+    pluto->rle = plutovg_rle_create();
+    pluto->clippath = nullptr;
+    pluto->clip.x = 0.0;
+    pluto->clip.y = 0.0;
+    pluto->clip.w = surface->width;
+    pluto->clip.h = surface->height;
+    pluto->outline_data = nullptr;
+    pluto->outline_size = 0;
+    return pluto;
+}
+
+plutovg_t* plutovg_reference(plutovg_t* pluto)
+{
+    ++pluto->ref;
+    return pluto;
+}
+
+void plutovg_destroy(plutovg_t* pluto)
+{
+    if (pluto == nullptr)
+        return;
+
+    if (--pluto->ref == 0)
+    {
+        while (pluto->state)
+        {
+            plutovg_state_t* state = pluto->state;
+            pluto->state = state->next;
+            plutovg_state_destroy(state);
+        }
+
+        plutovg_surface_destroy(pluto->surface);
+        plutovg_path_destroy(pluto->path);
+        plutovg_rle_destroy(pluto->rle);
+        plutovg_rle_destroy(pluto->clippath);
+        free(pluto->outline_data);
+        delete pluto;
+    }
+}
+
+int plutovg_get_reference_count(const plutovg_t* pluto)
+{
+    return pluto->ref;
+}
+
+void plutovg_save(plutovg_t* pluto)
+{
+    plutovg_state_t* newstate = plutovg_state_clone(pluto->state);
+    newstate->next = pluto->state;
+    pluto->state = newstate;
+}
+
+void plutovg_restore(plutovg_t* pluto)
+{
+    plutovg_state_t* oldstate = pluto->state;
+    pluto->state = oldstate->next;
+    plutovg_state_destroy(oldstate);
+}
+
+plutovg_color_t* plutovg_set_rgb(plutovg_t* pluto, double r, double g, double b)
+{
+    return plutovg_set_rgba(pluto, r, g, b, 1.0);
+}
+
+plutovg_color_t* plutovg_set_rgba(plutovg_t* pluto, double r, double g, double b, double a)
+{
+    plutovg_paint_t* paint = &pluto->state->paint;
+    paint->type = plutovg_paint_type_color;
+    plutovg_color_init_rgba(&paint->color, r, g, b, a);
+    return &paint->color;
+}
+
+plutovg_color_t* plutovg_set_color(plutovg_t* pluto, const plutovg_color_t* color)
+{
+    return plutovg_set_rgba(pluto, color->r, color->g, color->b, color->a);
+}
+
+plutovg_gradient_t* plutovg_set_linear_gradient(plutovg_t* pluto, double x1, double y1, double x2, double y2)
+{
+    plutovg_paint_t* paint = &pluto->state->paint;
+    paint->type = plutovg_paint_type_gradient;
+    plutovg_gradient_init_linear(&paint->gradient, x1, y1, x2, y2);
+    return &paint->gradient;
+}
+
+plutovg_gradient_t* plutovg_set_radial_gradient(plutovg_t* pluto, double cx, double cy, double cr, double fx, double fy,
+                                                double fr)
+{
+    plutovg_paint_t* paint = &pluto->state->paint;
+    paint->type = plutovg_paint_type_gradient;
+    plutovg_gradient_init_radial(&paint->gradient, cx, cy, cr, fx, fy, fr);
+    return &paint->gradient;
+}
+
+plutovg_texture_t* plutovg_set_texture_surface(plutovg_t* pluto, plutovg_surface_t* surface, double x, double y)
+{
+    plutovg_texture_t* texture = plutovg_set_texture(pluto, surface, plutovg_texture_type_plain);
+    plutovg_matrix_init_translate(&texture->matrix, x, y);
+    return texture;
+}
+
+plutovg_texture_t* plutovg_set_texture(plutovg_t* pluto, plutovg_surface_t* surface, plutovg_texture_type_t type)
+{
+    plutovg_paint_t* paint = &pluto->state->paint;
+    paint->type = plutovg_paint_type_texture;
+    plutovg_texture_init(&paint->texture, surface, type);
+    return &paint->texture;
+}
+
+void plutovg_set_operator(plutovg_t* pluto, plutovg_operator_t op)
+{
+    pluto->state->op = op;
+}
+
+void plutovg_set_opacity(plutovg_t* pluto, double opacity)
+{
+    pluto->state->opacity = opacity;
+}
+
+void plutovg_set_fill_rule(plutovg_t* pluto, plutovg_fill_rule_t fill_rule)
+{
+    pluto->state->winding = fill_rule;
+}
+
+plutovg_operator_t plutovg_get_operator(const plutovg_t* pluto)
+{
+    return pluto->state->op;
+}
+
+double plutovg_get_opacity(const plutovg_t* pluto)
+{
+    return pluto->state->opacity;
+}
+
+plutovg_fill_rule_t plutovg_get_fill_rule(const plutovg_t* pluto)
+{
+    return pluto->state->winding;
+}
+
+void plutovg_set_line_width(plutovg_t* pluto, double width)
+{
+    pluto->state->stroke.width = width;
+}
+
+void plutovg_set_line_cap(plutovg_t* pluto, plutovg_line_cap_t cap)
+{
+    pluto->state->stroke.cap = cap;
+}
+
+void plutovg_set_line_join(plutovg_t* pluto, plutovg_line_join_t join)
+{
+    pluto->state->stroke.join = join;
+}
+
+void plutovg_set_miter_limit(plutovg_t* pluto, double limit)
+{
+    pluto->state->stroke.miterlimit = limit;
+}
+
+void plutovg_set_dash(plutovg_t* pluto, double offset, const double* data, int size)
+{
+    plutovg_dash_destroy(pluto->state->stroke.dash);
+    pluto->state->stroke.dash = plutovg_dash_create(offset, data, size);
+}
+
+double plutovg_get_line_width(const plutovg_t* pluto)
+{
+    return pluto->state->stroke.width;
+}
+
+plutovg_line_cap_t plutovg_get_line_cap(const plutovg_t* pluto)
+{
+    return pluto->state->stroke.cap;
+}
+
+plutovg_line_join_t plutovg_get_line_join(const plutovg_t* pluto)
+{
+    return pluto->state->stroke.join;
+}
+
+double plutovg_get_miter_limit(const plutovg_t* pluto)
+{
+    return pluto->state->stroke.miterlimit;
+}
+
+void plutovg_translate(plutovg_t* pluto, double x, double y)
+{
+    plutovg_matrix_translate(&pluto->state->matrix, x, y);
+}
+
+void plutovg_scale(plutovg_t* pluto, double x, double y)
+{
+    plutovg_matrix_scale(&pluto->state->matrix, x, y);
+}
+
+void plutovg_rotate(plutovg_t* pluto, double radians, double x, double y)
+{
+    plutovg_matrix_rotate(&pluto->state->matrix, radians, x, y);
+}
+
+void plutovg_transform(plutovg_t* pluto, const plutovg_matrix_t* matrix)
+{
+    plutovg_matrix_multiply(&pluto->state->matrix, matrix, &pluto->state->matrix);
+}
+
+void plutovg_set_matrix(plutovg_t* pluto, const plutovg_matrix_t* matrix)
+{
+    pluto->state->matrix = *matrix;
+}
+
+void plutovg_identity_matrix(plutovg_t* pluto)
+{
+    plutovg_matrix_init_identity(&pluto->state->matrix);
+}
+
+void plutovg_get_matrix(const plutovg_t* pluto, plutovg_matrix_t* matrix)
+{
+    *matrix = pluto->state->matrix;
+}
+
+void plutovg_move_to(plutovg_t* pluto, double x, double y)
+{
+    plutovg_path_move_to(pluto->path, x, y);
+}
+
+void plutovg_line_to(plutovg_t* pluto, double x, double y)
+{
+    plutovg_path_line_to(pluto->path, x, y);
+}
+
+void plutovg_quad_to(plutovg_t* pluto, double x1, double y1, double x2, double y2)
+{
+    plutovg_path_quad_to(pluto->path, x1, y1, x2, y2);
+}
+
+void plutovg_cubic_to(plutovg_t* pluto, double x1, double y1, double x2, double y2, double x3, double y3)
+{
+    plutovg_path_cubic_to(pluto->path, x1, y1, x2, y2, x3, y3);
+}
+
+void plutovg_rel_move_to(plutovg_t* pluto, double x, double y)
+{
+    plutovg_path_rel_move_to(pluto->path, x, y);
+}
+
+void plutovg_rel_line_to(plutovg_t* pluto, double x, double y)
+{
+    plutovg_path_rel_line_to(pluto->path, x, y);
+}
+
+void plutovg_rel_quad_to(plutovg_t* pluto, double x1, double y1, double x2, double y2)
+{
+    plutovg_path_rel_quad_to(pluto->path, x1, y1, x2, y2);
+}
+
+void plutovg_rel_cubic_to(plutovg_t* pluto, double x1, double y1, double x2, double y2, double x3, double y3)
+{
+    plutovg_path_rel_cubic_to(pluto->path, x1, y1, x2, y2, x3, y3);
+}
+
+void plutovg_rect(plutovg_t* pluto, double x, double y, double w, double h)
+{
+    plutovg_path_add_rect(pluto->path, x, y, w, h);
+}
+
+void plutovg_round_rect(plutovg_t* pluto, double x, double y, double w, double h, double rx, double ry)
+{
+    plutovg_path_add_round_rect(pluto->path, x, y, w, h, rx, ry);
+}
+
+void plutovg_ellipse(plutovg_t* pluto, double cx, double cy, double rx, double ry)
+{
+    plutovg_path_add_ellipse(pluto->path, cx, cy, rx, ry);
+}
+
+void plutovg_circle(plutovg_t* pluto, double cx, double cy, double r)
+{
+    plutovg_ellipse(pluto, cx, cy, r, r);
+}
+
+void plutovg_add_path(plutovg_t* pluto, const plutovg_path_t* path)
+{
+    plutovg_path_add_path(pluto->path, path, nullptr);
+}
+
+void plutovg_new_path(plutovg_t* pluto)
+{
+    plutovg_path_clear(pluto->path);
+}
+
+void plutovg_close_path(plutovg_t* pluto)
+{
+    plutovg_path_close(pluto->path);
+}
+
+plutovg_path_t* plutovg_get_path(const plutovg_t* pluto)
+{
+    return pluto->path;
+}
+
+void plutovg_fill(plutovg_t* pluto)
+{
+    plutovg_fill_preserve(pluto);
+    plutovg_new_path(pluto);
+}
+
+void plutovg_stroke(plutovg_t* pluto)
+{
+    plutovg_stroke_preserve(pluto);
+    plutovg_new_path(pluto);
+}
+
+void plutovg_clip(plutovg_t* pluto)
+{
+    plutovg_clip_preserve(pluto);
+    plutovg_new_path(pluto);
+}
+
+void plutovg_paint(plutovg_t* pluto)
+{
+    plutovg_state_t* state = pluto->state;
+    if (state->clippath == nullptr && pluto->clippath == nullptr)
+    {
+        plutovg_path_t* path = plutovg_path_create();
+        plutovg_path_add_rect(path, pluto->clip.x, pluto->clip.y, pluto->clip.w, pluto->clip.h);
+        plutovg_matrix_t matrix;
+        plutovg_matrix_init_identity(&matrix);
+        pluto->clippath = plutovg_rle_create();
+        plutovg_rle_rasterize(pluto, pluto->clippath, path, &matrix, &pluto->clip, nullptr, plutovg_fill_rule_non_zero);
+        plutovg_path_destroy(path);
+    }
+
+    plutovg_rle_t* rle = state->clippath ? state->clippath : pluto->clippath;
+    plutovg_blend(pluto, rle);
+}
+
+void plutovg_fill_preserve(plutovg_t* pluto)
+{
+    plutovg_state_t* state = pluto->state;
+    plutovg_rle_clear(pluto->rle);
+    plutovg_rle_rasterize(pluto, pluto->rle, pluto->path, &state->matrix, &pluto->clip, nullptr, state->winding);
+    plutovg_rle_clip_path(pluto->rle, state->clippath);
+    plutovg_blend(pluto, pluto->rle);
+}
+
+void plutovg_stroke_preserve(plutovg_t* pluto)
+{
+    plutovg_state_t* state = pluto->state;
+    plutovg_rle_clear(pluto->rle);
+    plutovg_rle_rasterize(pluto, pluto->rle, pluto->path, &state->matrix, &pluto->clip, &state->stroke,
+                          plutovg_fill_rule_non_zero);
+    plutovg_rle_clip_path(pluto->rle, state->clippath);
+    plutovg_blend(pluto, pluto->rle);
+}
+
+void plutovg_clip_preserve(plutovg_t* pluto)
+{
+    plutovg_state_t* state = pluto->state;
+    if (state->clippath)
+    {
+        plutovg_rle_clear(pluto->rle);
+        plutovg_rle_rasterize(pluto, pluto->rle, pluto->path, &state->matrix, &pluto->clip, nullptr, state->winding);
+        plutovg_rle_clip_path(state->clippath, pluto->rle);
+    }
+    else
+    {
+        state->clippath = plutovg_rle_create();
+        plutovg_rle_rasterize(pluto, state->clippath, pluto->path, &state->matrix, &pluto->clip, nullptr, state->winding);
+    }
+}
+
+void plutovg_reset_clip(plutovg_t* pluto)
+{
+    plutovg_rle_destroy(pluto->state->clippath);
+    pluto->state->clippath = nullptr;
+}

--- a/source/plutovg/plutovg.h
+++ b/source/plutovg/plutovg.h
@@ -1,0 +1,254 @@
+#ifndef PLUTOVG_H
+#define PLUTOVG_H
+
+typedef struct plutovg_surface plutovg_surface_t;
+
+plutovg_surface_t* plutovg_surface_create(int width, int height);
+plutovg_surface_t* plutovg_surface_create_for_data(unsigned char* data, int width, int height, int stride);
+plutovg_surface_t* plutovg_surface_reference(plutovg_surface_t* surface);
+void plutovg_surface_destroy(plutovg_surface_t* surface);
+int plutovg_surface_get_reference_count(const plutovg_surface_t* surface);
+unsigned char* plutovg_surface_get_data(const plutovg_surface_t* surface);
+int plutovg_surface_get_width(const plutovg_surface_t* surface);
+int plutovg_surface_get_height(const plutovg_surface_t* surface);
+int plutovg_surface_get_stride(const plutovg_surface_t* surface);
+
+typedef struct {
+    double x;
+    double y;
+} plutovg_point_t;
+
+typedef struct {
+    double x;
+    double y;
+    double w;
+    double h;
+} plutovg_rect_t;
+
+void plutovg_rect_init(plutovg_rect_t* rect, double x, double y, double w, double h);
+void plutovg_rect_init_zero(plutovg_rect_t* rect);
+
+typedef struct {
+    double m00; double m10;
+    double m01; double m11;
+    double m02; double m12;
+} plutovg_matrix_t;
+
+void plutovg_matrix_init(plutovg_matrix_t* matrix, double m00, double m10, double m01, double m11, double m02, double m12);
+void plutovg_matrix_init_identity(plutovg_matrix_t* matrix);
+void plutovg_matrix_init_translate(plutovg_matrix_t* matrix, double x, double y);
+void plutovg_matrix_init_scale(plutovg_matrix_t* matrix, double x, double y);
+void plutovg_matrix_init_shear(plutovg_matrix_t* matrix, double x, double y);
+void plutovg_matrix_init_rotate(plutovg_matrix_t* matrix, double radians, double x, double y);
+void plutovg_matrix_translate(plutovg_matrix_t* matrix, double x, double y);
+void plutovg_matrix_scale(plutovg_matrix_t* matrix, double x, double y);
+void plutovg_matrix_shear(plutovg_matrix_t* matrix, double x, double y);
+void plutovg_matrix_rotate(plutovg_matrix_t* matrix, double radians, double x, double y);
+void plutovg_matrix_multiply(plutovg_matrix_t* matrix, const plutovg_matrix_t* a, const plutovg_matrix_t* b);
+int plutovg_matrix_invert(plutovg_matrix_t* matrix);
+void plutovg_matrix_map(const plutovg_matrix_t* matrix, double x, double y, double* _x, double* _y);
+void plutovg_matrix_map_point(const plutovg_matrix_t* matrix, const plutovg_point_t* src, plutovg_point_t* dst);
+void plutovg_matrix_map_rect(const plutovg_matrix_t* matrix, const plutovg_rect_t* src, plutovg_rect_t* dst);
+
+typedef struct plutovg_path plutovg_path_t;
+
+typedef enum {
+    plutovg_path_element_move_to,
+    plutovg_path_element_line_to,
+    plutovg_path_element_cubic_to,
+    plutovg_path_element_close
+} plutovg_path_element_t;
+
+plutovg_path_t* plutovg_path_create(void);
+plutovg_path_t* plutovg_path_reference(plutovg_path_t* path);
+void plutovg_path_destroy(plutovg_path_t* path);
+int plutovg_path_get_reference_count(const plutovg_path_t* path);
+void plutovg_path_move_to(plutovg_path_t* path, double x, double y);
+void plutovg_path_line_to(plutovg_path_t* path, double x, double y);
+void plutovg_path_quad_to(plutovg_path_t* path, double x1, double y1, double x2, double y2);
+void plutovg_path_cubic_to(plutovg_path_t* path, double x1, double y1, double x2, double y2, double x3, double y3);
+void plutovg_path_close(plutovg_path_t* path);
+void plutovg_path_rel_move_to(plutovg_path_t* path, double x, double y);
+void plutovg_path_rel_line_to(plutovg_path_t* path, double x, double y);
+void plutovg_path_rel_quad_to(plutovg_path_t* path, double x1, double y1, double x2, double y2);
+void plutovg_path_rel_cubic_to(plutovg_path_t* path, double x1, double y1, double x2, double y2, double x3, double y3);
+void plutovg_path_add_rect(plutovg_path_t* path, double x, double y, double w, double h);
+void plutovg_path_add_round_rect(plutovg_path_t* path, double x, double y, double w, double h, double rx, double ry);
+void plutovg_path_add_ellipse(plutovg_path_t* path, double cx, double cy, double rx, double ry);
+void plutovg_path_add_circle(plutovg_path_t* path, double cx, double cy, double r);
+void plutovg_path_add_path(plutovg_path_t* path, const plutovg_path_t* source, const plutovg_matrix_t* matrix);
+void plutovg_path_transform(plutovg_path_t* path, const plutovg_matrix_t* matrix);
+void plutovg_path_get_current_point(const plutovg_path_t* path, double* x, double* y);
+int plutovg_path_get_element_count(const plutovg_path_t* path);
+
+const plutovg_path_element_t* plutovg_path_get_elements(const plutovg_path_t* path);
+const plutovg_point_t* plutovg_path_get_points(const plutovg_path_t* path);
+
+int plutovg_path_get_point_count(const plutovg_path_t* path);
+void plutovg_path_clear(plutovg_path_t* path);
+int plutovg_path_empty(const plutovg_path_t* path);
+plutovg_path_t* plutovg_path_clone(const plutovg_path_t* path);
+plutovg_path_t* plutovg_path_clone_flat(const plutovg_path_t* path);
+
+typedef struct {
+    double r;
+    double g;
+    double b;
+    double a;
+} plutovg_color_t;
+
+void plutovg_color_init_rgb(plutovg_color_t* color, double r, double g, double b);
+void plutovg_color_init_rgba(plutovg_color_t* color, double r, double g, double b, double a);
+
+typedef enum {
+    plutovg_spread_method_pad,
+    plutovg_spread_method_reflect,
+    plutovg_spread_method_repeat
+} plutovg_spread_method_t;
+
+typedef struct plutovg_gradient plutovg_gradient_t;
+
+typedef enum {
+    plutovg_gradient_type_linear,
+    plutovg_gradient_type_radial
+} plutovg_gradient_type_t;
+
+typedef struct {
+    double offset;
+    plutovg_color_t color;
+} plutovg_gradient_stop_t;
+
+void plutovg_gradient_init_linear(plutovg_gradient_t* gradient, double x1, double y1, double x2, double y2);
+void plutovg_gradient_init_radial(plutovg_gradient_t* gradient, double cx, double cy, double cr, double fx, double fy, double fr);
+void plutovg_gradient_set_type(plutovg_gradient_t* gradient, plutovg_gradient_type_t type);
+plutovg_gradient_type_t plutovg_gradient_get_type(const plutovg_gradient_t* gradient);
+void plutovg_gradient_set_spread(plutovg_gradient_t* gradient, plutovg_spread_method_t spread);
+plutovg_spread_method_t plutovg_gradient_get_spread(const plutovg_gradient_t* gradient);
+void plutovg_gradient_set_matrix(plutovg_gradient_t* gradient, const plutovg_matrix_t* matrix);
+void plutovg_gradient_get_matrix(const plutovg_gradient_t* gradient, plutovg_matrix_t* matrix);
+void plutovg_gradient_add_stop_rgb(plutovg_gradient_t* gradient, double offset, double r, double g, double b);
+void plutovg_gradient_add_stop_rgba(plutovg_gradient_t* gradient, double offset, double r, double g, double b, double a);
+void plutovg_gradient_add_stop(plutovg_gradient_t* gradient, const plutovg_gradient_stop_t* stop);
+void plutovg_gradient_clear_stops(plutovg_gradient_t* gradient);
+int plutovg_gradient_get_stop_count(const plutovg_gradient_t* gradient);
+plutovg_gradient_stop_t* plutovg_gradient_get_stops(const plutovg_gradient_t* gradient);
+void plutovg_gradient_get_values_linear(const plutovg_gradient_t* gradient, double* x1, double* y1, double* x2, double* y2);
+void plutovg_gradient_get_values_radial(const plutovg_gradient_t* gradient, double* cx, double* cy, double* cr, double* fx, double* fy, double* fr);
+void plutovg_gradient_set_values_linear(plutovg_gradient_t* gradient, double x1, double y1, double x2, double y2);
+void plutovg_gradient_set_values_radial(plutovg_gradient_t* gradient, double cx, double cy, double cr, double fx, double fy, double fr);
+void plutovg_gradient_set_opacity(plutovg_gradient_t* paint, double opacity);
+double plutovg_gradient_get_opacity(const plutovg_gradient_t* paint);
+
+typedef struct plutovg_texture plutovg_texture_t;
+
+typedef enum {
+    plutovg_texture_type_plain,
+    plutovg_texture_type_tiled
+} plutovg_texture_type_t;
+
+void plutovg_texture_init(plutovg_texture_t* texture, plutovg_surface_t* surface, plutovg_texture_type_t type);
+void plutovg_texture_set_type(plutovg_texture_t* texture, plutovg_texture_type_t type);
+plutovg_texture_type_t plutovg_texture_get_type(const plutovg_texture_t* texture);
+void plutovg_texture_set_matrix(plutovg_texture_t* texture, const plutovg_matrix_t* matrix);
+void plutovg_texture_get_matrix(const plutovg_texture_t* texture, plutovg_matrix_t* matrix);
+void plutovg_texture_set_surface(plutovg_texture_t* texture, plutovg_surface_t* surface);
+plutovg_surface_t* plutovg_texture_get_surface(const plutovg_texture_t* texture);
+void plutovg_texture_set_opacity(plutovg_texture_t* texture, double opacity);
+double plutovg_texture_get_opacity(const plutovg_texture_t* texture);
+
+typedef enum {
+    plutovg_line_cap_butt,
+    plutovg_line_cap_round,
+    plutovg_line_cap_square
+} plutovg_line_cap_t;
+
+typedef enum {
+    plutovg_line_join_miter,
+    plutovg_line_join_round,
+    plutovg_line_join_bevel
+} plutovg_line_join_t;
+
+typedef enum {
+    plutovg_fill_rule_non_zero,
+    plutovg_fill_rule_even_odd
+} plutovg_fill_rule_t;
+
+typedef enum {
+    plutovg_operator_src,
+    plutovg_operator_src_over,
+    plutovg_operator_dst_in,
+    plutovg_operator_dst_out
+} plutovg_operator_t;
+
+typedef struct plutovg plutovg_t;
+
+plutovg_t* plutovg_create(plutovg_surface_t* surface);
+plutovg_t* plutovg_reference(plutovg_t* pluto);
+void plutovg_destroy(plutovg_t* pluto);
+int plutovg_get_reference_count(const plutovg_t* pluto);
+void plutovg_save(plutovg_t* pluto);
+void plutovg_restore(plutovg_t* pluto);
+
+plutovg_color_t* plutovg_set_rgb(plutovg_t* pluto, double r, double g, double b);
+plutovg_color_t* plutovg_set_rgba(plutovg_t* pluto, double r, double g, double b, double a);
+plutovg_color_t* plutovg_set_color(plutovg_t* pluto, const plutovg_color_t* color);
+
+plutovg_gradient_t* plutovg_set_linear_gradient(plutovg_t* pluto, double x1, double y1, double x2, double y2);
+plutovg_gradient_t* plutovg_set_radial_gradient(plutovg_t* pluto, double cx, double cy, double cr, double fx, double fy, double fr);
+
+plutovg_texture_t* plutovg_set_texture_surface(plutovg_t* pluto, plutovg_surface_t* surface, double x, double y);
+plutovg_texture_t* plutovg_set_texture(plutovg_t* pluto, plutovg_surface_t* surface, plutovg_texture_type_t type);
+
+void plutovg_set_operator(plutovg_t* pluto, plutovg_operator_t op);
+void plutovg_set_opacity(plutovg_t* pluto, double opacity);
+void plutovg_set_fill_rule(plutovg_t* pluto, plutovg_fill_rule_t fill_rule);
+plutovg_operator_t plutovg_get_operator(const plutovg_t* pluto);
+double plutovg_get_opacity(const plutovg_t* pluto);
+plutovg_fill_rule_t plutovg_get_fill_rule(const plutovg_t* pluto);
+
+void plutovg_set_line_width(plutovg_t* pluto, double width);
+void plutovg_set_line_cap(plutovg_t* pluto, plutovg_line_cap_t cap);
+void plutovg_set_line_join(plutovg_t* pluto, plutovg_line_join_t join);
+void plutovg_set_miter_limit(plutovg_t* pluto, double limit);
+void plutovg_set_dash(plutovg_t* pluto, double offset, const double* data, int size);
+double plutovg_get_line_width(const plutovg_t* pluto);
+plutovg_line_cap_t plutovg_get_line_cap(const plutovg_t* pluto);
+plutovg_line_join_t plutovg_get_line_join(const plutovg_t* pluto);
+double plutovg_get_miter_limit(const plutovg_t* pluto);
+
+void plutovg_translate(plutovg_t* pluto, double x, double y);
+void plutovg_scale(plutovg_t* pluto, double x, double y);
+void plutovg_rotate(plutovg_t* pluto, double radians, double x, double y);
+void plutovg_transform(plutovg_t* pluto, const plutovg_matrix_t* matrix);
+void plutovg_set_matrix(plutovg_t* pluto, const plutovg_matrix_t* matrix);
+void plutovg_identity_matrix(plutovg_t* pluto);
+void plutovg_get_matrix(const plutovg_t* pluto, plutovg_matrix_t* matrix);
+
+void plutovg_move_to(plutovg_t* pluto, double x, double y);
+void plutovg_line_to(plutovg_t* pluto, double x, double y);
+void plutovg_quad_to(plutovg_t* pluto, double x1, double y1, double x2, double y2);
+void plutovg_cubic_to(plutovg_t* pluto, double x1, double y1, double x2, double y2, double x3, double y3);
+void plutovg_rel_move_to(plutovg_t* pluto, double x, double y);
+void plutovg_rel_line_to(plutovg_t* pluto, double x, double y);
+void plutovg_rel_quad_to(plutovg_t* pluto, double x1, double y1, double x2, double y2);
+void plutovg_rel_cubic_to(plutovg_t* pluto, double x1, double y1, double x2, double y2, double x3, double y3);
+void plutovg_rect(plutovg_t* pluto, double x, double y, double w, double h);
+void plutovg_round_rect(plutovg_t* pluto, double x, double y, double w, double h, double rx, double ry);
+void plutovg_ellipse(plutovg_t* pluto, double cx, double cy, double rx, double ry);
+void plutovg_circle(plutovg_t* pluto, double cx, double cy, double r);
+void plutovg_add_path(plutovg_t* pluto, const plutovg_path_t* path);
+void plutovg_new_path(plutovg_t* pluto);
+void plutovg_close_path(plutovg_t* pluto);
+plutovg_path_t* plutovg_get_path(const plutovg_t* pluto);
+
+void plutovg_fill(plutovg_t* pluto);
+void plutovg_stroke(plutovg_t* pluto);
+void plutovg_clip(plutovg_t* pluto);
+void plutovg_paint(plutovg_t* pluto);
+
+void plutovg_fill_preserve(plutovg_t* pluto);
+void plutovg_stroke_preserve(plutovg_t* pluto);
+void plutovg_clip_preserve(plutovg_t* pluto);
+void plutovg_reset_clip(plutovg_t* pluto);
+
+#endif // PLUTOVG_H


### PR DESCRIPTION
This creates a `plutovg` subdirectory under `sources\` which contains a version of plutovg ported from C to C++.

## Notes

I have not added or modified any CMakeLists.txt files at this point. I've tested it in a private app where I simply added all of the sources (lunasvg and plutovg) to the app's CMakeLists.txt file.

`plutovg_path_add_path` -- currently I just iterate through the additional path, adding each element to the path, letting std::vector handle additional memory allocation as needed. An alternative would be to reserve the additional amount and use memcpy to copy the additional items.

`plutovg_rle_t::spans` and `plutovg_gradient::stops` could theoretically be converted to std::vector as well, replacing the calls to realloc/free used with them.
