### PR TITLE
Update minimum cmake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 
 project(lunasvg VERSION 2.4.0 LANGUAGES CXX C)
 


### PR DESCRIPTION
Hey!

Newer versions of CMake have started to throw a warning during configuring because lunasvg tries to target cmake 3.3 but support for these really old versions is going to be removed soon.

```
CMake Deprecation Warning at lib/third_party/lunasvg/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

This PR simply bumps the minimal version to 3.5 which was released in 2016 so most, if not all, users will most certainly have a much newer version already.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the minimum required CMake version to 3.5 for improved compatibility and features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->