### PR TITLE
Make the library build type public for using projects.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ add_subdirectory(3rdparty/plutovg)
 
 target_compile_definitions(lunasvg PRIVATE LUNASVG_BUILD)
 if(NOT BUILD_SHARED_LIBS)
-    target_compile_definitions(lunasvg PRIVATE LUNASVG_BUILD_STATIC)
+	target_compile_definitions(lunasvg PUBLIC LUNASVG_BUILD_STATIC)
 endif()
 
 if(LUNASVG_BUILD_EXAMPLES)


### PR DESCRIPTION
When lunasvg is being used in another CMake project then both projects need to define (or undefine) LUNASVG_BUILD_STATIC to get the required linkage. Change the definition to PUBLIC to export this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced accessibility of the `LUNASVG_BUILD_STATIC` definition for better integration with dependent targets.
- **Bug Fixes**
	- Addressed issues with the visibility of the `LUNASVG_BUILD_STATIC` compile definition, improving build configurations for linked targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->