### PR TITLE
Add callback to get missing fonts

### DIFF
--- a/include/lunasvg.h
+++ b/include/lunasvg.h
@@ -27,6 +27,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <functional>
 
 #if !defined(LUNASVG_BUILD_STATIC) && (defined(_WIN32) || defined(__CYGWIN__))
 #define LUNASVG_EXPORT __declspec(dllexport)
@@ -128,6 +129,50 @@ LUNASVG_API bool lunasvg_add_font_face_from_data(const char* family, bool bold, 
 #endif
 
 namespace lunasvg {
+
+/**
+ * @brief A callback function type to handle missing fonts.
+ * @param family The name of the font family.
+ * @param bold Use `true` for bold, `false` otherwise.
+ * @param italic Use `true` for italic, `false` otherwise.
+ * @return The path to the font file or an empty string if the font is not found.
+ */
+typedef std::function<const std::string(const std::string& family, bool bold, bool italic)> MissingFontCallback;
+
+/**
+ * @brief Allows to user to load custom fonts.
+ */
+namespace LUNASVG_API FontManager {
+    /**
+     * @brief Add a font face from a file to the cache.
+     * @param family The name of the font family. If an empty string is provided, the font will act as a fallback.
+     * @param bold Use `true` for bold, `false` otherwise.
+     * @param italic Use `true` for italic, `false` otherwise.
+     * @param filename The path to the font file.
+     * @return `true` if the font face was successfully added to the cache, `false` otherwise.
+     */
+    bool addFromFile(const std::string& family, bool bold, bool italic, const std::string& filename);
+
+    /**
+     * @brief Add a font face from memory to the cache.
+     * @param family The name of the font family. If an empty string is provided, the font will act as a fallback.
+     * @param bold Use `true` for bold, `false` otherwise.
+     * @param italic Use `true` for italic, `false` otherwise.
+     * @param data A pointer to the memory buffer containing the font data.
+     * @param length The size of the memory buffer in bytes.
+     * @param destroy_func Callback function to free the memory buffer when it is no longer needed.
+     * @param closure User-defined pointer passed to the `destroy_func` callback.
+     * @return `true` if the font face was successfully added to the cache, `false` otherwise.
+     */
+    bool addFromData(const std::string& family, bool bold, bool italic, const void* data, size_t length, lunasvg_destroy_func_t destroy_func, void* closure);
+
+
+    /**
+     * @brief Registers a callback function to handle missing fonts.
+     * @param callback The callback function to register.
+     */
+    void registerMissingFontCalback(MissingFontCallback callback);
+}
 
 /**
 * @note Bitmap pixel format is ARGB32_Premultiplied.

--- a/source/graphics.h
+++ b/source/graphics.h
@@ -11,6 +11,7 @@
 #include <array>
 #include <string>
 #include <map>
+#include <functional>
 
 namespace lunasvg {
 
@@ -421,12 +422,16 @@ class FontFaceCache {
 public:
     bool addFontFace(const std::string& family, bool bold, bool italic, const FontFace& face);
     FontFace getFontFace(const std::string_view& family, bool bold, bool italic);
+    void registerMissingFontCallback(const std::function<const std::string(const std::string&, bool, bool)>& callback);
 
 private:
     FontFaceCache();
     using FontFaceEntry = std::tuple<bool, bool, FontFace>;
     std::map<std::string, std::vector<FontFaceEntry>, std::less<>> m_table;
+    std::function<const std::string(const std::string&, bool, bool)> m_callback = nullptr;
     friend FontFaceCache* fontFaceCache();
+
+    FontFace tryRequestFontFace(const std::string_view& family, bool bold, bool italic);
 };
 
 FontFaceCache* fontFaceCache();

--- a/source/lunasvg.cpp
+++ b/source/lunasvg.cpp
@@ -29,6 +29,18 @@ bool lunasvg_add_font_face_from_data(const char* family, bool bold, bool italic,
 
 namespace lunasvg {
 
+bool FontManager::addFromFile(const std::string& family, bool bold, bool italic, const std::string& filename) {
+    return lunasvg_add_font_face_from_file(family.c_str(), bold, italic, filename.c_str());
+}
+
+bool FontManager::addFromData(const std::string& family, bool bold, bool italic, const void* data, size_t length, lunasvg_destroy_func_t destroy_func, void* closure) {
+    return lunasvg_add_font_face_from_data(family.c_str(), bold, italic, data, length, destroy_func, closure);
+}
+
+void FontManager::registerMissingFontCalback(std::function<const std::string(const std::string& family, bool bold, bool italic)> callback) {
+    fontFaceCache()->registerMissingFontCallback(callback);
+}
+
 Bitmap::Bitmap(int width, int height)
     : m_surface(plutovg_surface_create(width, height))
 {


### PR DESCRIPTION
This allows a user to register a callback to be called when a font is missing, as suggested in #178.

For now, I have made the API more C++ style than the other add_font functions, but feedback on this is very welcome.