### PR TITLE
Added back plutovg as a submodule, added option to use system version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Build with meson
         run: |
           pip install meson
@@ -25,6 +27,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Build with meson
         run: |
           pip install meson
@@ -43,6 +47,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Build with meson
         run: |
           pip install meson

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "third_party/plutovg"]
-	path = third_party/plutovg
+[submodule "plutovg"]
+	path = plutovg
 	url = https://github.com/sammycage/plutovg.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/plutovg"]
+	path = third_party/plutovg
+	url = https://github.com/sammycage/plutovg.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,9 @@ set(LUNASVG_VERSION_MICRO 0)
 
 project(lunasvg LANGUAGES CXX VERSION ${LUNASVG_VERSION_MAJOR}.${LUNASVG_VERSION_MINOR}.${LUNASVG_VERSION_MICRO})
 
-option(LUNASVG_USE_SYSTEM_PLUTOVG "Use installed version of plutovg instead of bundled submodule" OFF)
-if (LUNASVG_USE_SYSTEM_PLUTOVG)
-    find_package(plutovg 0.0.4 REQUIRED)
-else()
-    add_subdirectory(third_party/plutovg)
+find_package(plutovg 0.0.4 QUIET)
+if(NOT plutovg_FOUND)
+    add_subdirectory(plutovg)
 endif()
 
 set(lunasvg_sources

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,15 +6,12 @@ set(LUNASVG_VERSION_MICRO 0)
 
 project(lunasvg LANGUAGES CXX VERSION ${LUNASVG_VERSION_MAJOR}.${LUNASVG_VERSION_MINOR}.${LUNASVG_VERSION_MICRO})
 
-include(FetchContent)
-FetchContent_Declare(plutovg
-    GIT_REPOSITORY https://github.com/sammycage/plutovg.git
-    GIT_TAG main
-    GIT_SHALLOW ON
-    FIND_PACKAGE_ARGS 0.0.4
-)
-
-FetchContent_MakeAvailable(plutovg)
+option(LUNASVG_USE_SYSTEM_PLUTOVG "Use installed version of plutovg instead of bundled submodule" OFF)
+if (LUNASVG_USE_SYSTEM_PLUTOVG)
+    find_package(plutovg 0.0.4 REQUIRED)
+else()
+    add_subdirectory(third_party/plutovg)
+endif()
 
 set(lunasvg_sources
     source/lunasvg.cpp


### PR DESCRIPTION
This PR adds plutovg as a git submodule again and adds the new `LUNASVG_USE_SYSTEM_PLUTOVG`cmake option to allow using a system-installed version of plutovg instead if needed.

Closes #207