### PR TITLE
Add option to use system plutovg library in CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,17 @@ set(LUNASVG_VERSION_MICRO 1)
 
 project(lunasvg LANGUAGES CXX VERSION ${LUNASVG_VERSION_MAJOR}.${LUNASVG_VERSION_MINOR}.${LUNASVG_VERSION_MICRO})
 
-find_package(plutovg 1.0.0 QUIET)
+option(USE_SYSTEM_PLUTOVG "Use system plutovg library" OFF)
+
+if(USE_SYSTEM_PLUTOVG)
+    find_package(plutovg 1.0.0 QUIET)
+    if(NOT plutovg_FOUND)
+        message(WARNING "Could not find: plutovg>=1.0.0. Falling back to plutovg submodule.")
+    endif()
+endif()
+
 if(NOT plutovg_FOUND)
+    message(STATUS "Using plutovg submodule.")
     add_subdirectory(plutovg)
 endif()
 
@@ -57,7 +66,12 @@ target_include_directories(lunasvg PUBLIC
     $<INSTALL_INTERFACE:include/lunasvg>
 )
 
-target_link_libraries(lunasvg PRIVATE plutovg::plutovg)
+if(USE_SYSTEM_PLUTOVG AND plutovg_FOUND)
+    target_link_libraries(lunasvg PRIVATE plutovg::plutovg)
+else()
+    target_link_libraries(lunasvg PRIVATE plutovg)
+endif()
+
 target_compile_definitions(lunasvg PRIVATE LUNASVG_BUILD)
 if(NOT BUILD_SHARED_LIBS)
     target_compile_definitions(lunasvg PUBLIC LUNASVG_BUILD_STATIC)

--- a/README.md
+++ b/README.md
@@ -142,6 +142,17 @@ target_link_libraries(your_target_name PRIVATE lunasvg::lunasvg)
 
 Replace `your_target_name` with the name of your executable or library target.
 
+Build Options
+LunaSVG provides several build options that can be configured using -D flags when running cmake. Below is a list of available options:
+
+USE_SYSTEM_PLUTOVG (default: OFF): Use the system-installed plutovg library (version 1.0.0 or higher) instead of the bundled submodule. If the system library is not found, the build will fall back to using the submodule.
+Example:
+
+```bash
+cmake -B build -DUSE_SYSTEM_PLUTOVG=ON .
+cmake --build build
+```
+
 ### Using Meson
 
 ```bash


### PR DESCRIPTION
This pull request introduces a new option to use the system-installed `plutovg` library instead of the submodule
As a distro (nixpkgs in this case) we want to unbundle vendored dependencies as much as possible to reduce the number of package versions we need to support in parallel.
This adds a new option `USE_SYSTEM_PLUTOVG` and modifying the build configuration to conditionally link the appropriate `plutovg` library based on this option.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to use a system-installed plutovg library during the build process.

- **Chores**
  - Improved build configuration to automatically fall back to the bundled plutovg library if the system version is unavailable.
  - Updated documentation with new build options explaining how to enable the system plutovg library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->