### PR TITLE
Support fetching plutovg via pkg-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ project(lunasvg LANGUAGES CXX VERSION ${LUNASVG_VERSION_MAJOR}.${LUNASVG_VERSION
 
 option(USE_SYSTEM_PLUTOVG "Use system plutovg library" OFF)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
 if(USE_SYSTEM_PLUTOVG)
     find_package(plutovg 1.0.0 QUIET)
     if(NOT plutovg_FOUND)

--- a/cmake/Findplutovg.cmake
+++ b/cmake/Findplutovg.cmake
@@ -1,0 +1,25 @@
+
+find_package(plutovg ${plutovg_FIND_VERSION} QUIET CONFIG)
+if(plutovg_FOUND)
+    return()
+endif()
+
+find_package(PkgConfig QUIET)
+if (PKG_CONFIG_FOUND)
+    pkg_check_modules(_PLUTOVG plutovg>=${plutovg_FIND_VERSION} QUIET)
+
+    if (_PLUTOVG_FOUND)
+        add_library(plutovg::plutovg UNKNOWN IMPORTED)
+
+        set(plutovg_FOUND ON)
+        if (NOT BUILD_STATIC)
+            set_target_properties(plutovg::plutovg PROPERTIES IMPORTED_LOCATION_NOCONFIG "${_PLUTOVG_LINK_LIBRARIES}")
+            target_include_directories(plutovg::plutovg INTERFACE ${_PLUTOVG_INCLUDE_DIRS})
+            target_compile_options(plutovg::plutovg INTERFACE ${_PLUTOVG_CFLAGS_OTHER})
+        else()
+            set_target_properties(plutovg::plutovg PROPERTIES IMPORTED_LOCATION_NOCONFIG "${_PLUTOVG_STATIC_LINK_LIBRARIES}")
+            target_include_directories(plutovg::plutovg INTERFACE ${_PLUTOVG_STATIC_INCLUDE_DIRS})
+            target_compile_options(plutovg::plutovg INTERFACE ${_PLUTOVG_STATIC_CFLAGS_OTHER})
+        endif()
+    endif()
+endif()


### PR DESCRIPTION
The cmake logic currently only looks for a module or a config but if plutovg was installed using meson then only a pkg-config file can be found.

This PR adds a local module to check for the config and otherwise fall back to pkg-config.