### PR TITLE
Add LUNASVG_INSTALL and PLUTOVG_INSTALL CMake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,60 +77,62 @@ if(LUNASVG_DISABLE_LOAD_SYSTEM_FONTS)
     target_compile_definitions(lunasvg PRIVATE LUNASVG_DISABLE_LOAD_SYSTEM_FONTS)
 endif()
 
-include(GNUInstallDirs)
-include(CMakePackageConfigHelpers)
+option(LUNASVG_INSTALL "Generate the install target" ON)
+if(LUNASVG_INSTALL)
+    include(GNUInstallDirs)
+    include(CMakePackageConfigHelpers)
 
-configure_package_config_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/lunasvgConfig.cmake.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/lunasvgConfig.cmake"
-    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/lunasvg
-)
+    configure_package_config_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/lunasvgConfig.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/lunasvgConfig.cmake"
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/lunasvg
+    )
 
-write_basic_package_version_file(lunasvgConfigVersion.cmake
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY SameMajorVersion
-)
+    write_basic_package_version_file(lunasvgConfigVersion.cmake
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY SameMajorVersion
+    )
 
-install(FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/lunasvg.h
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/lunasvg
-)
+    install(FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/lunasvg.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/lunasvg
+    )
 
-install(TARGETS lunasvg
-    EXPORT lunasvgTargets
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
+    install(TARGETS lunasvg
+        EXPORT lunasvgTargets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
 
-install(EXPORT lunasvgTargets
-    FILE lunasvgTargets.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/lunasvg
-    NAMESPACE lunasvg::
-)
+    install(EXPORT lunasvgTargets
+        FILE lunasvgTargets.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/lunasvg
+        NAMESPACE lunasvg::
+    )
 
-install(FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/lunasvgConfig.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/lunasvgConfigVersion.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/lunasvg
-)
+    install(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/lunasvgConfig.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/lunasvgConfigVersion.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/lunasvg
+    )
 
-export(EXPORT lunasvgTargets
-    FILE ${CMAKE_CURRENT_BINARY_DIR}/lunasvgTargets.cmake
-    NAMESPACE lunasvg::
-)
+    export(EXPORT lunasvgTargets
+        FILE ${CMAKE_CURRENT_BINARY_DIR}/lunasvgTargets.cmake
+        NAMESPACE lunasvg::
+    )
 
-file(RELATIVE_PATH lunasvg_pc_prefix_relative
-    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    "${CMAKE_INSTALL_PREFIX}"
-)
+    file(RELATIVE_PATH lunasvg_pc_prefix_relative
+        "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+        "${CMAKE_INSTALL_PREFIX}"
+    )
 
-set(lunasvg_pc_cflags "")
-if(NOT BUILD_SHARED_LIBS)
-    string(APPEND lunasvg_pc_cflags " -DLUNASVG_BUILD_STATIC")
-endif()
+    set(lunasvg_pc_cflags "")
+    if(NOT BUILD_SHARED_LIBS)
+        string(APPEND lunasvg_pc_cflags " -DLUNASVG_BUILD_STATIC")
+    endif()
 
-string(CONFIGURE [[
+    string(CONFIGURE [[
 prefix=${pcfiledir}/@lunasvg_pc_prefix_relative@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
@@ -144,10 +146,11 @@ Cflags: -I${includedir}/lunasvg@lunasvg_pc_cflags@
 Libs: -L${libdir} -llunasvg
 ]] lunasvg_pc @ONLY)
 
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/lunasvg.pc" "${lunasvg_pc}")
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/lunasvg.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-)
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/lunasvg.pc" "${lunasvg_pc}")
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/lunasvg.pc"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+    )
+endif()
 
 option(LUNASVG_BUILD_EXAMPLES "Build examples" ON)
 if(LUNASVG_BUILD_EXAMPLES)

--- a/README.md
+++ b/README.md
@@ -218,6 +218,19 @@ cmake -B build -DUSE_SYSTEM_PLUTOVG=ON .
 cmake --build build
 ```
 
+LUNASVG_INSTALL (default: ON): Enable installing the library to the system/install prefix. Useful for preventing a separate installation of the library when statically linked to your project.
+Example:
+
+```bash
+# Static libraries don't need a separate install
+set(LUNASVG_INSTALL OFF)
+set(PLUTOVG_INSTALL OFF)
+FetchContent_Declare(
+    lunasvg
+    # ...
+)
+```
+
 ### Using Meson
 
 ```bash

--- a/plutovg/CMakeLists.txt
+++ b/plutovg/CMakeLists.txt
@@ -96,56 +96,59 @@ write_basic_package_version_file(plutovgConfigVersion.cmake
     COMPATIBILITY SameMajorVersion
 )
 
-install(FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/plutovg.h
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/plutovg
-)
 
-install(TARGETS plutovg
-    EXPORT plutovgTargets
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
+option(PLUTOVG_INSTALL "Generate the install target" ON)
+if(PLUTOVG_INSTALL)
+    install(FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/plutovg.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/plutovg
+    )
 
-install(EXPORT plutovgTargets
-    FILE plutovgTargets.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/plutovg
-    NAMESPACE plutovg::
-)
+    install(TARGETS plutovg
+        EXPORT plutovgTargets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
 
-install(FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/plutovgConfig.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/plutovgConfigVersion.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/plutovg
-)
+    install(EXPORT plutovgTargets
+        FILE plutovgTargets.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/plutovg
+        NAMESPACE plutovg::
+    )
 
-export(EXPORT plutovgTargets
-    FILE ${CMAKE_CURRENT_BINARY_DIR}/plutovgTargets.cmake
-    NAMESPACE plutovg::
-)
+    install(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/plutovgConfig.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/plutovgConfigVersion.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/plutovg
+    )
 
-file(RELATIVE_PATH plutovg_pc_prefix_relative
-    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    "${CMAKE_INSTALL_PREFIX}"
-)
+    export(EXPORT plutovgTargets
+        FILE ${CMAKE_CURRENT_BINARY_DIR}/plutovgTargets.cmake
+        NAMESPACE plutovg::
+    )
 
-set(plutovg_pc_cflags "")
-set(plutovg_pc_libs_private "")
+    file(RELATIVE_PATH plutovg_pc_prefix_relative
+        "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+        "${CMAKE_INSTALL_PREFIX}"
+    )
 
-if(MATH_LIBRARY)
-    string(APPEND plutovg_pc_libs_private " -lm")
-endif()
+    set(plutovg_pc_cflags "")
+    set(plutovg_pc_libs_private "")
 
-if(Threads_FOUND AND CMAKE_THREAD_LIBS_INIT)
-    string(APPEND plutovg_pc_libs_private " ${CMAKE_THREAD_LIBS_INIT}")
-endif()
+    if(MATH_LIBRARY)
+        string(APPEND plutovg_pc_libs_private " -lm")
+    endif()
 
-if(NOT BUILD_SHARED_LIBS)
-    string(APPEND plutovg_pc_cflags " -DPLUTOVG_BUILD_STATIC")
-endif()
+    if(Threads_FOUND AND CMAKE_THREAD_LIBS_INIT)
+        string(APPEND plutovg_pc_libs_private " ${CMAKE_THREAD_LIBS_INIT}")
+    endif()
 
-string(CONFIGURE [[
+    if(NOT BUILD_SHARED_LIBS)
+        string(APPEND plutovg_pc_cflags " -DPLUTOVG_BUILD_STATIC")
+    endif()
+
+    string(CONFIGURE [[
 prefix=${pcfiledir}/@plutovg_pc_prefix_relative@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
@@ -159,11 +162,12 @@ Libs: -L${libdir} -lplutovg
 Libs.private:@plutovg_pc_libs_private@
 ]] plutovg_pc @ONLY)
 
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/plutovg.pc" "${plutovg_pc}")
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/plutovg.pc" "${plutovg_pc}")
 
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/plutovg.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/plutovg.pc"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+    )
+endif()
 
 option(PLUTOVG_BUILD_EXAMPLES "Build examples" ON)
 if(PLUTOVG_BUILD_EXAMPLES)


### PR DESCRIPTION
I've added `LUNASVG_INSTALL` and `PLUTOVG_INSTALL` options to control if the libraries are installed.  This is useful because users of the library don't need to install the library separately if it is just being statically linked to whatever their program is anyways.