### PR TITLE
Fix infinite loop, specificity bug

### DIFF
--- a/source/svgparser.cpp
+++ b/source/svgparser.cpp
@@ -214,7 +214,7 @@ static bool matchPseudoClassSelector(const PseudoClassSelector& selector, const 
         while(sibling) {
             if(sibling->id() == element->id())
                 return false;
-            sibling = element->previousElement();
+            sibling = sibling->previousElement();
         }
 
         return true;
@@ -225,7 +225,7 @@ static bool matchPseudoClassSelector(const PseudoClassSelector& selector, const 
         while(sibling) {
             if(sibling->id() == element->id())
                 return false;
-            sibling = element->nextElement();
+            sibling = sibling->nextElement();
         }
 
         return true;
@@ -570,6 +570,9 @@ static RuleDataList parseStyleSheet(std::string_view input)
                 specificity += (simpleSelector.id == ElementID::Star) ? 0x0 : 0x1;
                 for(const auto& attributeSelector : simpleSelector.attributeSelectors) {
                     specificity += (attributeSelector.id == PropertyID::Id) ? 0x10000 : 0x100;
+                }
+                for(const auto& pseudoClassSelector : simpleSelector.pseudoClassSelectors) {
+                    specificity += 0x100;
                 }
             }
 


### PR DESCRIPTION
This PR fixes a infinite loop when processing some SVG files. Fixing that loop also exposed an additional bug that caused the test svg fail to render incorrectly. The fix adds pseudo-class selectors to the specificity calculation with weight 0x100 (same as class and attribute selectors per CSS spec). Now rect:first-of-type has specificity 0x101 (element + pseudo-class) while plain rect has 0x1, so the first rectangle will correctly be red.

## Test SVG

```xml
<?xml version="1.0" encoding="UTF-8"?>
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100">
  <style>
    rect:first-of-type { fill: red; }
    rect { fill: blue; }
  </style>
  <rect x="10" y="10" width="80" height="80"/>
  <rect x="110" y="10" width="80" height="80"/>
</svg>
```
