### PR TITLE
add node-canvas to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ $ svg2png input.svg 512x512 0xff00ffff
 - [CARLA Simulator](https://carla.org/)
 - [AUI Framework](https://github.com/aui-framework/aui)
 - [Software Companions](http://www.softwarecompanions.com)
+- [node-canvas](https://github.com/Automattic/node-canvas)
 
 ## License
 


### PR DESCRIPTION
Hello,

[node-canvas](https://github.com/Automattic/node-canvas) is grateful for LunaSVG. Previously we used librsvg which had a burdensome build process. When we moved to static builds it just became impossible to keep using.

Here's the patch we're using: https://github.com/chearon/lunasvg/commit/3fd8ba9e0cd5cf0af36b1bda2d0a3bbaf8bd8da7.

A lot of the changes overlap with the changes that wxWidgets made in their fork. Would be nice to put our heads together some day and standardize an interface that works for users that need deep integration.

Thank you!